### PR TITLE
Add DynamoDB support with conditional compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +198,385 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-config"
+version = "1.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0149602eeaf915158e14029ba0c78dedb8c08d554b024d54c8f239aab46511d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01c9521fa01558f750d183c8c68c81b0155b9d193a4ba7f84c36bd1b6d04a06"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce527fb7e53ba9626fc47824f25e256250556c40d8f81d27dd92aa38239d632"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15204f660c916ca74c17dc8dad054b513343618807e779d9d41fdc3635d3343c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f18e53542c522459e757f81e274783a78f8c81acdfc8d1522ee8a18b5fb1c66"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.92.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532f4d866012ffa724a4385c82e8dd0e59f0ca0e600f3f22d4c03b6824b34e4a"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be6fbbfa1a57724788853a623378223fe828fc4c09b146c992f0c95b6256174"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35452ec3f001e1f2f6db107b6373f1f48f05ec63ba2c5c9fa91f07dad32af11"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "127fcfad33b7dfc531141fda7e1c402ac65f88aca5511a4d31e2e3d2cd01ce9c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445d5d720c99eed0b4aa674ed00d835d9b1427dd73e04adaf2f94c6b2d6f9fca"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "623254723e8dfd535f566ee7b2381645f8981da086b5c4aa26c0c41582bb1d2c"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.12",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.35",
+ "rustls-native-certs 0.8.2",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2db31f727935fc63c6eeae8b37b438847639ec330a9161ece694efba257e0c54"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1881b1ea6d313f9890710d65c158bdab6fb08c91ea825f74c1c8c357baf4cc"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d28a63441360c477465f80c7abac3b9c4d075ca638f982e605b7dc2a2c7156c9"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bbe9d018d646b96c7be063dd07987849862b0e6d07c778aad7d93d1be6c1ef0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7204f9fd94749a7c53b26da1b961b4ac36bf070ef1e0b94bb09f79d4f6c193"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f535879a207fce0db74b679cfc3e91a3159c8144d717d55f5832aea9eef46e"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab77cdd036b11056d2a30a7af7b775789fb024bf216acc13884c6c97752ae56"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d79fb68e3d7fe5d4833ea34dc87d2e97d26d3086cb3da660bb6b1f76d98680b6"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -219,6 +604,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -323,6 +718,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cargo-lock"
 version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +860,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -601,6 +1025,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -613,6 +1038,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -702,6 +1133,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -875,7 +1312,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -945,6 +1401,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,13 +1427,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -988,9 +1492,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1003,16 +1507,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2 0.4.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "hyper-util",
+ "rustls 0.23.35",
+ "rustls-native-certs 0.8.2",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.0",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1268,6 +1851,8 @@ version = "0.41.0-scylladb"
 dependencies = [
  "anyhow",
  "assert_approx_eq",
+ "aws-config",
+ "aws-sdk-dynamodb",
  "base64 0.22.1",
  "bytes",
  "cargo-lock",
@@ -1563,7 +2148,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1792,6 +2377,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -2131,6 +2722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,10 +2759,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2189,6 +2786,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2423,12 +3034,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.3.0",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2475,6 +3167,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "scylla"
@@ -2554,7 +3256,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2787,6 +3502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,7 +3553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3032,6 +3753,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.35",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,6 +3836,22 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3222,6 +3979,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3231,6 +3994,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3272,6 +4041,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3754,6 +4529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,6 +4598,12 @@ dependencies = [
  "syn 2.0.104",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ rune = "0.13"
 rust_decimal = "1.36"
 rust-embed = "8"
 scylla = { version = "1.3", features = ["openssl-010", "chrono-04"] }
+aws-config = { version = "1", optional = true }
+aws-sdk-dynamodb = { version = "1", optional = true }
 search_path = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -72,9 +74,15 @@ assert_approx_eq = "1"
 rstest = "0.22"
 tokio = { version = "1", features = ["rt", "test-util", "macros"] }
 
+[features]
+default = ["cassandra"]
+cassandra = []
+dynamodb = ["aws-config", "aws-sdk-dynamodb"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(fetch_extended_version_info)',
+    'cfg(feature, values("cassandra", "dynamodb"))',
 ] }
 
 [profile.release]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::scripting::cass_error::CassError;
+use crate::scripting::db_error::DbError;
 use hdrhistogram::serialization::interval_log::IntervalLogWriterError;
 use hdrhistogram::serialization::V2DeflateSerializeError;
 use rune::alloc;
@@ -13,8 +13,8 @@ pub enum LatteError {
     #[error("Context data could not be deserialized: {0}")]
     ContextDataDecode(#[from] rmp_serde::decode::Error),
 
-    #[error("Cassandra error: {0}")]
-    Cassandra(#[source] Box<CassError>),
+    #[error("Database error: {0}")]
+    Database(#[source] Box<DbError>),
 
     #[error("Failed to read file {0:?}: {1}")]
     ScriptRead(PathBuf, #[source] rune::source::FromPathError),
@@ -50,15 +50,15 @@ pub enum LatteError {
     OutOfMemory(#[from] alloc::Error),
 }
 
-impl From<CassError> for LatteError {
-    fn from(err: CassError) -> Self {
-        LatteError::Cassandra(Box::new(err))
+impl From<DbError> for LatteError {
+    fn from(err: DbError) -> Self {
+        LatteError::Database(Box::new(err))
     }
 }
 
-impl From<Box<CassError>> for LatteError {
-    fn from(err: Box<CassError>) -> Self {
-        LatteError::Cassandra(err)
+impl From<Box<DbError>> for LatteError {
+    fn from(err: Box<DbError>) -> Self {
+        LatteError::Database(err)
     }
 }
 

--- a/src/exec/workload.rs
+++ b/src/exec/workload.rs
@@ -9,8 +9,9 @@ use std::time::Instant;
 
 use crate::config::ValidationStrategy;
 use crate::error::LatteError;
-use crate::scripting::cass_error::{CassError, CassErrorKind};
-use crate::scripting::context::{handle_retry_error, Context};
+use crate::scripting::common::handle_retry_error;
+use crate::scripting::context::Context;
+use crate::scripting::db_error::{DbError, DbErrorKind};
 use crate::stats::latency::LatencyDistributionRecorder;
 use crate::stats::session::SessionStats;
 use rand::distributions::{Distribution, WeightedIndex};
@@ -189,7 +190,7 @@ impl Program {
     }
 
     /// Checks if Rune function call result is an error and if so, converts it into [`LatteError`].
-    /// Cassandra errors are returned as [`LatteError::Cassandra`].
+    /// Database errors are returned as [`LatteError::Database`].
     /// All other errors are returned as [`LatteError::FunctionResult`].
     /// If result is not an `Err`, it is returned as-is.
     ///
@@ -201,9 +202,9 @@ impl Program {
             Value::Result(result) => match result.take().unwrap() {
                 Ok(value) => Ok(value),
                 Err(Value::Any(e)) => {
-                    if e.borrow_ref().unwrap().type_hash() == CassError::type_hash() {
-                        let e = e.take_downcast::<CassError>().unwrap();
-                        return Err(LatteError::Cassandra(Box::new(e)));
+                    if e.borrow_ref().unwrap().type_hash() == DbError::type_hash() {
+                        let e = e.take_downcast::<DbError>().unwrap();
+                        return Err(LatteError::Database(Box::new(e)));
                     }
 
                     let e = Value::Any(e);
@@ -458,7 +459,7 @@ impl Workload {
         let mut is_ok = false;
         let retry_number = self.context.retry_number;
         while current_retries_counter < retry_number {
-            let current_err: CassError;
+            let current_err: DbError;
             // NOTE: Create a separate scope inside of the loop
             //       to be able to run additional retry-related async context functions.
             {
@@ -476,8 +477,8 @@ impl Workload {
                         is_ok = true;
                         break;
                     }
-                    Err(LatteError::Cassandra(boxed_err))
-                        if matches!(boxed_err.0, CassErrorKind::Overloaded(_, _)) =>
+                    Err(LatteError::Database(boxed_err))
+                        if matches!(boxed_err.0, DbErrorKind::Overloaded(..)) =>
                     {
                         // don't stop on overload errors;
                         // they are being counted by the context stats anyways
@@ -488,8 +489,8 @@ impl Workload {
                     //       which may be called anytime in a rune function.
                     //       May be used for data validation and other needs which require re-run
                     //       of a rune function.
-                    Err(LatteError::Cassandra(boxed_err))
-                        if matches!(&boxed_err.0, CassErrorKind::CustomError(_)) =>
+                    Err(LatteError::Database(boxed_err))
+                        if matches!(boxed_err.0, DbErrorKind::CustomError(_)) =>
                     {
                         state.operation_failed(function, duration);
                         match &self.context.validation_strategy {
@@ -497,7 +498,7 @@ impl Workload {
                                 current_err = *boxed_err;
                             }
                             ValidationStrategy::FailFast => {
-                                return Err(LatteError::Cassandra(boxed_err))
+                                return Err(LatteError::Database(boxed_err))
                             }
                             ValidationStrategy::Ignore => {
                                 current_err = *boxed_err;
@@ -521,7 +522,7 @@ impl Workload {
         if is_ok {
             return Ok((cycle, end_time));
         }
-        Err(CassError::query_retries_exceeded(self.context.retry_number).into())
+        Err(DbError::query_retries_exceeded(self.context.retry_number).into())
     }
 
     /// Returns the reference to the contained context.

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use crate::config::{
 use crate::error::{LatteError, Result};
 use crate::exec::{par_execute, ExecutionOptions};
 use crate::report::{PathAndSummary, Report, RunConfigCmp};
-use crate::scripting::connect::ClusterInfo;
+use crate::scripting::common::ClusterInfo;
 use crate::scripting::context::Context;
 use crate::stats::histogram::HistogramWriter;
 use crate::stats::{BenchmarkCmp, BenchmarkStats, Recorder};

--- a/src/scripting/cassandra/bind.rs
+++ b/src/scripting/cassandra/bind.rs
@@ -1,7 +1,7 @@
 //! Functions for binding rune values to CQL parameters
 
-use crate::scripting::cass_error::{CassError, CassErrorKind};
-use crate::scripting::cql_types::Uuid;
+use super::cass_error::{CassError, CassErrorKind};
+use super::cql_types::Uuid;
 use chrono::{NaiveDate, NaiveTime};
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/src/scripting/cassandra/cass_error.rs
+++ b/src/scripting/cassandra/cass_error.rs
@@ -371,3 +371,6 @@ impl Display for QueryInfo {
         )
     }
 }
+
+pub type DbError = CassError;
+pub type DbErrorKind = CassErrorKind;

--- a/src/scripting/cassandra/connect.rs
+++ b/src/scripting/cassandra/connect.rs
@@ -1,6 +1,6 @@
+use super::cass_error::{CassError, CassErrorKind};
+use super::context::Context;
 use crate::config::ConnectionConf;
-use crate::scripting::cass_error::{CassError, CassErrorKind};
-use crate::scripting::context::Context;
 use openssl::ssl::{SslContextBuilder, SslFiletype, SslMethod, SslVerifyMode};
 use scylla::client::session::TlsContext;
 use scylla::client::PoolSize;
@@ -75,9 +75,4 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, CassError> {
         conf.retry_interval,
         conf.validation_strategy,
     ))
-}
-
-pub struct ClusterInfo {
-    pub name: String,
-    pub db_version: String,
 }

--- a/src/scripting/cassandra/cql_types.rs
+++ b/src/scripting/cassandra/cql_types.rs
@@ -40,7 +40,7 @@ impl Uuid {
 }
 
 pub mod i64 {
-    use crate::scripting::cql_types::{Float32, Int16, Int32, Int8};
+    use super::{Float32, Int16, Int32, Int8};
 
     /// Converts a Rune integer to i8 (Cassandra tinyint)
     #[rune::function(instance)]
@@ -80,7 +80,7 @@ pub mod i64 {
 }
 
 pub mod f64 {
-    use crate::scripting::cql_types::{Float32, Int16, Int32, Int8};
+    use super::{Float32, Int16, Int32, Int8};
 
     #[rune::function(instance)]
     pub fn to_i8(value: f64) -> Int8 {

--- a/src/scripting/cassandra/functions.rs
+++ b/src/scripting/cassandra/functions.rs
@@ -1,0 +1,215 @@
+use super::cass_error::{CassError, CassErrorKind};
+use super::context::Context;
+use super::cql_types::Uuid;
+use rune::runtime::{Mut, Ref};
+use rune::{Any, Value};
+use std::ops::Deref;
+
+/// Creates a new UUID for current iteration
+#[rune::function]
+pub fn uuid(i: i64) -> Uuid {
+    Uuid::new(i)
+}
+
+#[rune::function(instance)]
+pub async fn prepare(mut ctx: Mut<Context>, key: Ref<str>, cql: Ref<str>) -> Result<(), CassError> {
+    ctx.prepare(&key, &cql).await
+}
+
+#[rune::function(instance)]
+pub async fn signal_failure(ctx: Ref<Context>, message: Ref<str>) -> Result<(), CassError> {
+    ctx.signal_failure(message.deref()).await
+}
+
+#[rune::function(instance)]
+pub async fn execute(ctx: Ref<Context>, cql: Ref<str>) -> Result<Value, CassError> {
+    ctx.execute(cql.deref()).await
+}
+
+#[rune::function(instance)]
+pub async fn execute_with_validation(
+    ctx: Ref<Context>,
+    cql: Ref<str>,
+    validation_args: Vec<Value>,
+) -> Result<Value, CassError> {
+    match validation_args.as_slice() {
+        // (int): expected_rows
+        [Value::Integer(expected_rows)] => {
+            ctx.execute_with_validation(
+                cql.deref(),
+                *expected_rows as u64,
+                *expected_rows as u64,
+                "",
+            )
+            .await
+        }
+        // (int, int): expected_rows_num_min, expected_rows_num_max
+        [Value::Integer(min), Value::Integer(max)] => {
+            ctx.execute_with_validation(cql.deref(), *min as u64, *max as u64, "")
+                .await
+        }
+        // (int, str): expected_rows, custom_err_msg
+        [Value::Integer(expected_rows), Value::String(custom_err_msg)] => {
+            ctx.execute_with_validation(
+                cql.deref(),
+                *expected_rows as u64,
+                *expected_rows as u64,
+                &custom_err_msg.borrow_ref().unwrap(),
+            )
+            .await
+        }
+        // (int, int, str): expected_rows_num_min, expected_rows_num_max, custom_err_msg
+        [Value::Integer(min), Value::Integer(max), Value::String(custom_err_msg)] => {
+            ctx.execute_with_validation(
+                cql.deref(),
+                *min as u64,
+                *max as u64,
+                &custom_err_msg.borrow_ref().unwrap(),
+            )
+            .await
+        }
+        _ => Err(CassError(CassErrorKind::Error(
+            "Invalid arguments for execute_with_validation".to_string(),
+        ))),
+    }
+}
+
+#[rune::function(instance)]
+pub async fn execute_with_result(ctx: Ref<Context>, cql: Ref<str>) -> Result<Value, CassError> {
+    ctx.execute_with_result(cql.deref()).await
+}
+
+#[rune::function(instance)]
+pub async fn execute_prepared(
+    ctx: Ref<Context>,
+    key: Ref<str>,
+    params: Value,
+) -> Result<Value, CassError> {
+    ctx.execute_prepared(&key, params).await
+}
+
+#[rune::function(instance)]
+pub async fn execute_prepared_with_validation(
+    ctx: Ref<Context>,
+    key: Ref<str>,
+    params: Value,
+    validation_args: Vec<Value>,
+) -> Result<Value, CassError> {
+    match validation_args.as_slice() {
+        // (int): expected_rows
+        [Value::Integer(expected_rows)] => {
+            ctx.execute_prepared_with_validation(
+                &key,
+                params,
+                *expected_rows as u64,
+                *expected_rows as u64,
+                "",
+            )
+            .await
+        }
+        // (int, int): expected_rows_num_min, expected_rows_num_max
+        [Value::Integer(min), Value::Integer(max)] => {
+            ctx.execute_prepared_with_validation(&key, params, *min as u64, *max as u64, "")
+                .await
+        }
+        // (int, str): expected_rows, custom_err_msg
+        [Value::Integer(expected_rows), Value::String(custom_err_msg)] => {
+            ctx.execute_prepared_with_validation(
+                &key,
+                params,
+                *expected_rows as u64,
+                *expected_rows as u64,
+                &custom_err_msg.borrow_ref().unwrap(),
+            )
+            .await
+        }
+        // (int, int, str): expected_rows_num_min, expected_rows_num_max, custom_err_msg
+        [Value::Integer(min), Value::Integer(max), Value::String(custom_err_msg)] => {
+            ctx.execute_prepared_with_validation(
+                &key,
+                params,
+                *min as u64,
+                *max as u64,
+                &custom_err_msg.borrow_ref().unwrap(),
+            )
+            .await
+        }
+        _ => Err(CassError(CassErrorKind::Error(
+            "Invalid arguments for execute_prepared_with_validation".to_string(),
+        ))),
+    }
+}
+
+#[rune::function(instance)]
+pub async fn execute_prepared_with_result(
+    ctx: Ref<Context>,
+    key: Ref<str>,
+    params: Value,
+) -> Result<Value, CassError> {
+    ctx.execute_prepared_with_result(&key, params).await
+}
+
+#[rune::function(instance)]
+pub async fn batch_prepared(
+    ctx: Ref<Context>,
+    keys: Vec<Ref<str>>,
+    params: Vec<Value>,
+) -> Result<(), CassError> {
+    ctx.batch_prepared(keys.iter().map(|k| k.deref()).collect(), params)
+        .await
+}
+
+#[rune::function(instance)]
+pub async fn init_partition_row_distribution_preset(
+    mut ctx: Mut<Context>,
+    preset_name: Ref<str>,
+    row_count: u64,
+    rows_per_partitions_base: u64,
+    rows_per_partitions_groups: Ref<str>,
+) -> Result<(), CassError> {
+    ctx.init_partition_row_distribution_preset(
+        &preset_name,
+        row_count,
+        rows_per_partitions_base,
+        &rows_per_partitions_groups,
+    )
+    .await
+}
+
+/// This 'Partition' data type is exposed to rune scripts
+#[derive(Any)]
+pub struct Partition {
+    #[rune(get, set, copy, add_assign, sub_assign)]
+    idx: u64,
+
+    #[rune(get, copy)]
+    rows_num: u64,
+}
+
+#[rune::function(instance)]
+pub async fn get_partition_info(ctx: Ref<Context>, preset_name: Ref<str>, idx: u64) -> Partition {
+    let (idx, rows_num) = ctx
+        .get_partition_info(&preset_name, idx)
+        .await
+        .expect("failed to get partition");
+    Partition { idx, rows_num }
+}
+
+#[rune::function(instance)]
+pub async fn get_partition_idx(ctx: Ref<Context>, preset_name: Ref<str>, idx: u64) -> u64 {
+    let (idx, _rows_num) = ctx
+        .get_partition_info(&preset_name, idx)
+        .await
+        .expect("failed to get partition");
+    idx
+}
+
+#[rune::function(instance)]
+pub async fn get_datacenters(ctx: Ref<Context>) -> Result<Vec<String>, CassError> {
+    ctx.get_datacenters().await
+}
+
+#[rune::function(instance)]
+pub fn elapsed_secs(ctx: &Context) -> f64 {
+    ctx.elapsed_secs()
+}

--- a/src/scripting/cassandra/mod.rs
+++ b/src/scripting/cassandra/mod.rs
@@ -1,0 +1,6 @@
+mod bind;
+pub mod cass_error;
+pub mod connect;
+pub mod context;
+pub mod cql_types;
+pub mod functions;

--- a/src/scripting/common.rs
+++ b/src/scripting/common.rs
@@ -1,0 +1,57 @@
+use chrono::Utc;
+use rand::random;
+use std::time::Duration;
+use tracing::error;
+
+use super::context::Context;
+use super::db_error::DbError;
+
+pub struct ClusterInfo {
+    pub name: String,
+    pub db_version: String,
+}
+
+pub fn get_exponential_retry_interval(
+    min_interval: Duration,
+    max_interval: Duration,
+    current_attempt_num: u64,
+) -> Duration {
+    let min_interval_float: f64 = min_interval.as_secs_f64();
+    let mut current_interval: f64 =
+        min_interval_float * (2u64.pow(current_attempt_num.try_into().unwrap_or(0)) as f64);
+
+    // Add jitter
+    current_interval += random::<f64>() * min_interval_float;
+    current_interval -= min_interval_float / 2.0;
+
+    Duration::from_secs_f64(current_interval.min(max_interval.as_secs_f64()))
+}
+
+pub async fn handle_retry_error(ctxt: &Context, current_attempt_num: u64, current_error: DbError) {
+    let current_retry_interval = get_exponential_retry_interval(
+        ctxt.retry_interval.min,
+        ctxt.retry_interval.max,
+        current_attempt_num,
+    );
+
+    let mut next_attempt_str = String::new();
+    let is_last_attempt = current_attempt_num == ctxt.retry_number;
+    if !is_last_attempt {
+        next_attempt_str += &format!("[Retry in {} ms]", current_retry_interval.as_millis());
+    }
+    let err_msg = format!(
+        "{}: [ERROR][Attempt {}/{}]{} {}",
+        Utc::now().format("%Y-%m-%d %H:%M:%S%.3f"),
+        current_attempt_num,
+        ctxt.retry_number,
+        next_attempt_str,
+        current_error,
+    );
+    error!("{}", err_msg);
+    if !is_last_attempt {
+        ctxt.stats.try_lock().unwrap().store_retry_error(err_msg);
+        tokio::time::sleep(current_retry_interval).await;
+    } else {
+        eprintln!("{err_msg}");
+    }
+}

--- a/src/scripting/dynamodb/connect.rs
+++ b/src/scripting/dynamodb/connect.rs
@@ -1,0 +1,34 @@
+use super::context::Context;
+use super::dynamodb_error::{DynamoDBError, DynamoDBErrorKind};
+use crate::config::ConnectionConf;
+use aws_config::BehaviorVersion;
+use aws_sdk_dynamodb::config::{Credentials, Region};
+use aws_sdk_dynamodb::error::DisplayErrorContext;
+use aws_sdk_dynamodb::Client;
+
+pub async fn connect(conf: &ConnectionConf) -> Result<Context, DynamoDBError> {
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .endpoint_url(conf.addresses[0].clone())
+        .region(Region::new("us-east-1"))
+        .credentials_provider(Credentials::new("", "", None, None, ""))
+        .load()
+        .await;
+
+    let client = Client::new(&config);
+
+    // Validate connection by making a test request
+    client.list_tables().limit(1).send().await.map_err(|e| {
+        let addr = conf.addresses.get(0).cloned().unwrap_or_default();
+        DynamoDBError(DynamoDBErrorKind::FailedToConnect(
+            addr,
+            DisplayErrorContext(&e).to_string(),
+        ))
+    })?;
+
+    Ok(Context::new(
+        Some(client),
+        conf.retry_number,
+        conf.retry_interval,
+        conf.validation_strategy,
+    ))
+}

--- a/src/scripting/dynamodb/context.rs
+++ b/src/scripting/dynamodb/context.rs
@@ -1,0 +1,83 @@
+use super::dynamodb_error::{DynamoDBError, DynamoDBErrorKind};
+use crate::config::{RetryInterval, ValidationStrategy};
+use crate::error::LatteError;
+use crate::scripting::common::ClusterInfo;
+use crate::stats::session::SessionStats;
+use aws_sdk_dynamodb::Client;
+use rune::Any;
+use std::time::Instant;
+use try_lock::TryLock;
+
+#[derive(Any)]
+pub struct Context {
+    client: Option<Client>,
+    pub stats: TryLock<SessionStats>,
+    start_time: TryLock<Instant>,
+    pub retry_number: u64,
+    pub retry_interval: RetryInterval,
+    pub validation_strategy: ValidationStrategy,
+    #[rune(get, set, add_assign, copy)]
+    pub load_cycle_count: u64,
+}
+
+unsafe impl Send for Context {}
+unsafe impl Sync for Context {}
+
+impl Context {
+    pub fn new(
+        client: Option<Client>,
+        retry_number: u64,
+        retry_interval: RetryInterval,
+        validation_strategy: ValidationStrategy,
+    ) -> Context {
+        Context {
+            client,
+            stats: TryLock::new(SessionStats::new()),
+            start_time: TryLock::new(Instant::now()),
+            retry_number,
+            retry_interval,
+            validation_strategy,
+            load_cycle_count: 0,
+        }
+    }
+
+    pub fn clone(&self) -> Result<Self, LatteError> {
+        Ok(Context {
+            client: self.client.clone(),
+            stats: TryLock::new(SessionStats::default()),
+            start_time: TryLock::new(Instant::now()),
+            retry_number: self.retry_number,
+            retry_interval: self.retry_interval,
+            validation_strategy: self.validation_strategy,
+            load_cycle_count: self.load_cycle_count,
+        })
+    }
+
+    pub async fn cluster_info(&self) -> Result<Option<ClusterInfo>, DynamoDBError> {
+        Ok(Some(ClusterInfo {
+            name: "DynamoDB".to_string(),
+            db_version: "DynamoDB".to_string(),
+        }))
+    }
+
+    pub async fn signal_failure(&self, message: &str) -> Result<(), DynamoDBError> {
+        let err = DynamoDBError(DynamoDBErrorKind::CustomError(message.to_string()));
+        Err(err)
+    }
+
+    pub fn elapsed_secs(&self) -> f64 {
+        self.start_time.try_lock().unwrap().elapsed().as_secs_f64()
+    }
+
+    pub fn take_session_stats(&self) -> SessionStats {
+        let mut stats = self.stats.try_lock().unwrap();
+        let result = stats.clone();
+        stats.reset();
+        result
+    }
+
+    pub fn reset(&self) {
+        self.stats.try_lock().unwrap().reset();
+        *self.start_time.try_lock().unwrap() = Instant::now();
+    }
+}

--- a/src/scripting/dynamodb/dynamodb_error.rs
+++ b/src/scripting/dynamodb/dynamodb_error.rs
@@ -1,0 +1,49 @@
+use rune::alloc::fmt::TryWrite;
+use rune::runtime::VmResult;
+use rune::{vm_write, Any};
+use std::fmt::{Display, Formatter};
+
+#[derive(Any, Debug)]
+pub struct DynamoDBError(pub DynamoDBErrorKind);
+
+#[derive(Debug)]
+pub enum DynamoDBErrorKind {
+    FailedToConnect(String, String),
+    QueryRetriesExceeded(String),
+    Overloaded(String),
+    CustomError(String),
+    Error(String),
+}
+
+impl DynamoDBError {
+    pub fn query_retries_exceeded(retry_number: u64) -> DynamoDBError {
+        DynamoDBError(DynamoDBErrorKind::QueryRetriesExceeded(format!(
+            "Max retry attempts ({retry_number}) reached"
+        )))
+    }
+
+    #[rune::function(protocol = STRING_DISPLAY)]
+    pub fn string_display(&self, f: &mut rune::runtime::Formatter) -> VmResult<()> {
+        vm_write!(f, "{}", self.to_string());
+        VmResult::Ok(())
+    }
+}
+
+impl Display for DynamoDBError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            DynamoDBErrorKind::FailedToConnect(addr, e) => {
+                write!(f, "Failed to connect to DynamoDB at {}: {}", addr, e)
+            }
+            DynamoDBErrorKind::QueryRetriesExceeded(s) => write!(f, "QueryRetriesExceeded: {s}"),
+            DynamoDBErrorKind::Overloaded(s) => write!(f, "Overloaded: {s}"),
+            DynamoDBErrorKind::CustomError(s) => write!(f, "{s}"),
+            DynamoDBErrorKind::Error(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl std::error::Error for DynamoDBError {}
+
+pub type DbError = DynamoDBError;
+pub type DbErrorKind = DynamoDBErrorKind;

--- a/src/scripting/dynamodb/functions.rs
+++ b/src/scripting/dynamodb/functions.rs
@@ -1,0 +1,14 @@
+use super::context::Context;
+use super::dynamodb_error::DynamoDBError;
+use rune::runtime::Ref;
+use std::ops::Deref;
+
+#[rune::function(instance)]
+pub async fn signal_failure(ctx: Ref<Context>, message: Ref<str>) -> Result<(), DynamoDBError> {
+    ctx.signal_failure(message.deref()).await
+}
+
+#[rune::function(instance)]
+pub fn elapsed_secs(ctx: Ref<Context>) -> f64 {
+    ctx.elapsed_secs()
+}

--- a/src/scripting/dynamodb/mod.rs
+++ b/src/scripting/dynamodb/mod.rs
@@ -1,0 +1,4 @@
+pub mod connect;
+pub mod context;
+pub mod dynamodb_error;
+pub mod functions;

--- a/src/scripting/functions_common.rs
+++ b/src/scripting/functions_common.rs
@@ -1,6 +1,3 @@
-use crate::scripting::cass_error::{CassError, CassErrorKind};
-use crate::scripting::context::Context;
-use crate::scripting::cql_types::{Int8, Uuid};
 use crate::scripting::Resources;
 use chrono::Utc;
 use metrohash::MetroHash64;
@@ -9,15 +6,14 @@ use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use rune::macros::{quote, MacroContext, TokenStream};
 use rune::parse::Parser;
-use rune::runtime::{Function, Mut, Ref, VmError, VmResult};
-use rune::{ast, vm_try, Any, Value};
+use rune::runtime::{Function, VmError, VmResult};
+use rune::{ast, vm_try, Value};
 use statrs::distribution::{Normal, Uniform};
 use std::collections::HashMap;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io;
 use std::io::{BufRead, BufReader, ErrorKind, Read};
-use std::ops::Deref;
 
 /// Returns the literal value stored in the `params` map under the key given as the first
 /// macro arg, and if not found, returns the expression from the second arg.
@@ -40,17 +36,6 @@ pub fn param(
         None => quote!(#expr),
     };
     Ok(rhs.into_token_stream(ctx)?)
-}
-
-/// Creates a new UUID for current iteration
-#[rune::function]
-pub fn uuid(i: i64) -> Uuid {
-    Uuid::new(i)
-}
-
-#[rune::function]
-pub fn float_to_i8(value: f64) -> Option<Int8> {
-    Some(Int8((value as i64).try_into().ok()?))
 }
 
 /// Computes a hash of an integer value `i`.
@@ -264,207 +249,4 @@ pub fn read_resource_words(path: &str) -> io::Result<Vec<String>> {
         .split(|c: char| !c.is_alphabetic())
         .map(|s| s.to_string())
         .collect())
-}
-
-#[rune::function(instance)]
-pub async fn prepare(mut ctx: Mut<Context>, key: Ref<str>, cql: Ref<str>) -> Result<(), CassError> {
-    ctx.prepare(&key, &cql).await
-}
-
-#[rune::function(instance)]
-pub async fn signal_failure(ctx: Ref<Context>, message: Ref<str>) -> Result<(), CassError> {
-    ctx.signal_failure(message.deref()).await
-}
-
-#[rune::function(instance)]
-pub async fn execute(ctx: Ref<Context>, cql: Ref<str>) -> Result<Value, CassError> {
-    ctx.execute(cql.deref()).await
-}
-
-#[rune::function(instance)]
-pub async fn execute_with_validation(
-    ctx: Ref<Context>,
-    cql: Ref<str>,
-    validation_args: Vec<Value>,
-) -> Result<Value, CassError> {
-    match validation_args.as_slice() {
-        // (int): expected_rows
-        [Value::Integer(expected_rows)] => {
-            ctx.execute_with_validation(
-                cql.deref(),
-                *expected_rows as u64,
-                *expected_rows as u64,
-                "",
-            )
-            .await
-        }
-        // (int, int): expected_rows_num_min, expected_rows_num_max
-        [Value::Integer(min), Value::Integer(max)] => {
-            ctx.execute_with_validation(cql.deref(), *min as u64, *max as u64, "")
-                .await
-        }
-        // (int, str): expected_rows, custom_err_msg
-        [Value::Integer(expected_rows), Value::String(custom_err_msg)] => {
-            ctx.execute_with_validation(
-                cql.deref(),
-                *expected_rows as u64,
-                *expected_rows as u64,
-                &custom_err_msg.borrow_ref().unwrap(),
-            )
-            .await
-        }
-        // (int, int, str): expected_rows_num_min, expected_rows_num_max, custom_err_msg
-        [Value::Integer(min), Value::Integer(max), Value::String(custom_err_msg)] => {
-            ctx.execute_with_validation(
-                cql.deref(),
-                *min as u64,
-                *max as u64,
-                &custom_err_msg.borrow_ref().unwrap(),
-            )
-            .await
-        }
-        _ => Err(CassError(CassErrorKind::Error(
-            "Invalid arguments for execute_with_validation".to_string(),
-        ))),
-    }
-}
-
-#[rune::function(instance)]
-pub async fn execute_with_result(ctx: Ref<Context>, cql: Ref<str>) -> Result<Value, CassError> {
-    ctx.execute_with_result(cql.deref()).await
-}
-
-#[rune::function(instance)]
-pub async fn execute_prepared(
-    ctx: Ref<Context>,
-    key: Ref<str>,
-    params: Value,
-) -> Result<Value, CassError> {
-    ctx.execute_prepared(&key, params).await
-}
-
-#[rune::function(instance)]
-pub async fn execute_prepared_with_validation(
-    ctx: Ref<Context>,
-    key: Ref<str>,
-    params: Value,
-    validation_args: Vec<Value>,
-) -> Result<Value, CassError> {
-    match validation_args.as_slice() {
-        // (int): expected_rows
-        [Value::Integer(expected_rows)] => {
-            ctx.execute_prepared_with_validation(
-                &key,
-                params,
-                *expected_rows as u64,
-                *expected_rows as u64,
-                "",
-            )
-            .await
-        }
-        // (int, int): expected_rows_num_min, expected_rows_num_max
-        [Value::Integer(min), Value::Integer(max)] => {
-            ctx.execute_prepared_with_validation(&key, params, *min as u64, *max as u64, "")
-                .await
-        }
-        // (int, str): expected_rows, custom_err_msg
-        [Value::Integer(expected_rows), Value::String(custom_err_msg)] => {
-            ctx.execute_prepared_with_validation(
-                &key,
-                params,
-                *expected_rows as u64,
-                *expected_rows as u64,
-                &custom_err_msg.borrow_ref().unwrap(),
-            )
-            .await
-        }
-        // (int, int, str): expected_rows_num_min, expected_rows_num_max, custom_err_msg
-        [Value::Integer(min), Value::Integer(max), Value::String(custom_err_msg)] => {
-            ctx.execute_prepared_with_validation(
-                &key,
-                params,
-                *min as u64,
-                *max as u64,
-                &custom_err_msg.borrow_ref().unwrap(),
-            )
-            .await
-        }
-        _ => Err(CassError(CassErrorKind::Error(
-            "Invalid arguments for execute_prepared_with_validation".to_string(),
-        ))),
-    }
-}
-
-#[rune::function(instance)]
-pub async fn execute_prepared_with_result(
-    ctx: Ref<Context>,
-    key: Ref<str>,
-    params: Value,
-) -> Result<Value, CassError> {
-    ctx.execute_prepared_with_result(&key, params).await
-}
-
-#[rune::function(instance)]
-pub async fn batch_prepared(
-    ctx: Ref<Context>,
-    keys: Vec<Ref<str>>,
-    params: Vec<Value>,
-) -> Result<(), CassError> {
-    ctx.batch_prepared(keys.iter().map(|k| k.deref()).collect(), params)
-        .await
-}
-
-#[rune::function(instance)]
-pub async fn init_partition_row_distribution_preset(
-    mut ctx: Mut<Context>,
-    preset_name: Ref<str>,
-    row_count: u64,
-    rows_per_partitions_base: u64,
-    rows_per_partitions_groups: Ref<str>,
-) -> Result<(), CassError> {
-    ctx.init_partition_row_distribution_preset(
-        &preset_name,
-        row_count,
-        rows_per_partitions_base,
-        &rows_per_partitions_groups,
-    )
-    .await
-}
-
-/// This 'Partition' data type is exposed to rune scripts
-#[derive(Any)]
-pub struct Partition {
-    #[rune(get, set, copy, add_assign, sub_assign)]
-    idx: u64,
-
-    #[rune(get, copy)]
-    rows_num: u64,
-}
-
-#[rune::function(instance)]
-pub async fn get_partition_info(ctx: Ref<Context>, preset_name: Ref<str>, idx: u64) -> Partition {
-    let (idx, rows_num) = ctx
-        .get_partition_info(&preset_name, idx)
-        .await
-        .expect("failed to get partition");
-    Partition { idx, rows_num }
-}
-
-#[rune::function(instance)]
-pub async fn get_partition_idx(ctx: Ref<Context>, preset_name: Ref<str>, idx: u64) -> u64 {
-    let (idx, _rows_num) = ctx
-        .get_partition_info(&preset_name, idx)
-        .await
-        .expect("failed to get partition");
-    idx
-}
-
-#[rune::function(instance)]
-pub async fn get_datacenters(ctx: Ref<Context>) -> Result<Vec<String>, CassError> {
-    ctx.get_datacenters().await
-}
-
-#[rune::function(instance)]
-pub fn elapsed_secs(ctx: &Context) -> f64 {
-    ctx.elapsed_secs()
 }

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -1,15 +1,28 @@
-use crate::scripting::cass_error::CassError;
-use crate::scripting::context::Context;
 use rune::{ContextError, Module};
 use rust_embed::RustEmbed;
 use std::collections::HashMap;
 
-mod bind;
-pub mod cass_error;
-pub mod connect;
-pub mod context;
-mod cql_types;
-mod functions;
+pub mod common;
+mod functions_common;
+
+#[cfg(feature = "cassandra")]
+mod cassandra;
+#[cfg(feature = "dynamodb")]
+mod dynamodb;
+
+#[cfg(feature = "cassandra")]
+pub use cassandra::cass_error as db_error;
+#[cfg(feature = "cassandra")]
+pub use cassandra::connect;
+#[cfg(feature = "cassandra")]
+pub use cassandra::context;
+
+#[cfg(feature = "dynamodb")]
+pub use dynamodb::connect;
+#[cfg(feature = "dynamodb")]
+pub use dynamodb::context;
+#[cfg(feature = "dynamodb")]
+pub use dynamodb::dynamodb_error as db_error;
 
 #[derive(RustEmbed)]
 #[folder = "resources/"]
@@ -19,10 +32,16 @@ pub fn install(rune_ctx: &mut rune::Context, params: HashMap<String, String>) {
     try_install(rune_ctx, params).unwrap()
 }
 
+#[cfg(feature = "cassandra")]
 fn try_install(
     rune_ctx: &mut rune::Context,
     params: HashMap<String, String>,
 ) -> Result<(), ContextError> {
+    use cassandra::cass_error::CassError;
+    use cassandra::context::Context;
+    use cassandra::cql_types;
+    use cassandra::functions;
+
     let mut context_module = Module::default();
     context_module.ty::<Context>()?;
     context_module.function_meta(functions::prepare)?;
@@ -54,22 +73,8 @@ fn try_install(
     uuid_module.function_meta(cql_types::Uuid::string_display)?;
 
     let mut latte_module = Module::with_crate("latte")?;
-    latte_module.macro_("param", move |ctx, ts| functions::param(ctx, &params, ts))?;
-
-    latte_module.function_meta(functions::blob)?;
-    latte_module.function_meta(functions::text)?;
-    latte_module.function_meta(functions::vector)?;
-    latte_module.function_meta(functions::join)?;
-    latte_module.function_meta(functions::now_timestamp)?;
-    latte_module.function_meta(functions::hash)?;
-    latte_module.function_meta(functions::hash2)?;
-    latte_module.function_meta(functions::hash_range)?;
-    latte_module.function_meta(functions::hash_select)?;
+    install_common_functions(&mut latte_module, params)?;
     latte_module.function_meta(functions::uuid)?;
-    latte_module.function_meta(functions::normal)?;
-    latte_module.function_meta(functions::normal_f32)?;
-    latte_module.function_meta(functions::uniform)?;
-    latte_module.function_meta(functions::is_none)?;
 
     latte_module.function_meta(cql_types::i64::to_i32)?;
     latte_module.function_meta(cql_types::i64::to_i16)?;
@@ -84,12 +89,7 @@ fn try_install(
     latte_module.function_meta(cql_types::f64::clamp)?;
 
     let mut fs_module = Module::with_crate("fs")?;
-    fs_module.function_meta(functions::read_to_string)?;
-    fs_module.function_meta(functions::read_lines)?;
-    fs_module.function_meta(functions::read_words)?;
-    fs_module.function_meta(functions::read_resource_to_string)?;
-    fs_module.function_meta(functions::read_resource_lines)?;
-    fs_module.function_meta(functions::read_resource_words)?;
+    install_fs_functions(&mut fs_module)?;
 
     rune_ctx.install(&context_module)?;
     rune_ctx.install(&err_module)?;
@@ -97,5 +97,70 @@ fn try_install(
     rune_ctx.install(&latte_module)?;
     rune_ctx.install(&fs_module)?;
 
+    Ok(())
+}
+
+#[cfg(feature = "dynamodb")]
+fn try_install(
+    rune_ctx: &mut rune::Context,
+    params: HashMap<String, String>,
+) -> Result<(), ContextError> {
+    use dynamodb::context::Context;
+    use dynamodb::dynamodb_error::DynamoDBError;
+    use dynamodb::functions;
+
+    let mut context_module = Module::default();
+    context_module.ty::<Context>()?;
+    context_module.function_meta(functions::signal_failure)?;
+    context_module.function_meta(functions::elapsed_secs)?;
+
+    let mut err_module = Module::default();
+    err_module.ty::<DynamoDBError>()?;
+    err_module.function_meta(DynamoDBError::string_display)?;
+
+    let mut latte_module = Module::with_crate("latte")?;
+    install_common_functions(&mut latte_module, params)?;
+
+    let mut fs_module = Module::with_crate("fs")?;
+    install_fs_functions(&mut fs_module)?;
+
+    rune_ctx.install(&context_module)?;
+    rune_ctx.install(&err_module)?;
+    rune_ctx.install(&latte_module)?;
+    rune_ctx.install(&fs_module)?;
+
+    Ok(())
+}
+
+fn install_common_functions(
+    latte_module: &mut Module,
+    params: HashMap<String, String>,
+) -> Result<(), ContextError> {
+    latte_module.macro_("param", move |ctx, ts| {
+        functions_common::param(ctx, &params, ts)
+    })?;
+    latte_module.function_meta(functions_common::blob)?;
+    latte_module.function_meta(functions_common::text)?;
+    latte_module.function_meta(functions_common::vector)?;
+    latte_module.function_meta(functions_common::join)?;
+    latte_module.function_meta(functions_common::now_timestamp)?;
+    latte_module.function_meta(functions_common::hash)?;
+    latte_module.function_meta(functions_common::hash2)?;
+    latte_module.function_meta(functions_common::hash_range)?;
+    latte_module.function_meta(functions_common::hash_select)?;
+    latte_module.function_meta(functions_common::normal)?;
+    latte_module.function_meta(functions_common::normal_f32)?;
+    latte_module.function_meta(functions_common::uniform)?;
+    latte_module.function_meta(functions_common::is_none)?;
+    Ok(())
+}
+
+fn install_fs_functions(fs_module: &mut Module) -> Result<(), ContextError> {
+    fs_module.function_meta(functions_common::read_to_string)?;
+    fs_module.function_meta(functions_common::read_lines)?;
+    fs_module.function_meta(functions_common::read_words)?;
+    fs_module.function_meta(functions_common::read_resource_to_string)?;
+    fs_module.function_meta(functions_common::read_resource_lines)?;
+    fs_module.function_meta(functions_common::read_resource_words)?;
     Ok(())
 }

--- a/src/stats/session.rs
+++ b/src/stats/session.rs
@@ -1,8 +1,5 @@
 use crate::config::PRINT_RETRY_ERROR_LIMIT;
 use crate::stats::latency::LatencyDistributionRecorder;
-use scylla::errors::ExecutionError;
-use scylla::response::query_result::QueryResult;
-use scylla::response::PagingStateResponse;
 use std::collections::HashSet;
 use std::time::Duration;
 use tokio::time::Instant;
@@ -34,58 +31,11 @@ impl SessionStats {
         Instant::now()
     }
 
-    pub fn complete_request(
-        &mut self,
-        duration: Duration,
-        total_rows: Option<u64>,
-        rs: &Result<(QueryResult, PagingStateResponse), ExecutionError>,
-    ) {
+    pub fn complete_request(&mut self, duration: Duration, row_count: u64) {
         self.queue_length -= 1;
         self.resp_times_ns.record(duration);
         self.req_count += 1;
-        match rs {
-            Ok((ref page, _)) => match total_rows {
-                Some(n) => self.row_count += n,
-                None => {
-                    self.row_count += page
-                        .clone()
-                        .into_rows_result()
-                        .expect("Failed to read rows from the response")
-                        .rows_num() as u64
-                }
-            },
-            Err(e) => {
-                self.req_error_count += 1;
-                self.req_errors.insert(format!("{e}"));
-            }
-        }
-    }
-
-    pub fn complete_request_batch(
-        &mut self,
-        duration: Duration,
-        total_rows: Option<u64>,
-        rs: &Result<QueryResult, ExecutionError>,
-    ) {
-        self.queue_length -= 1;
-        self.resp_times_ns.record(duration);
-        self.req_count += 1;
-        match rs {
-            Ok(rs) => match total_rows {
-                Some(n) => self.row_count += n,
-                None => {
-                    self.row_count += rs
-                        .clone()
-                        .into_rows_result()
-                        .map(|r| r.rows_num())
-                        .unwrap_or(0) as u64
-                }
-            },
-            Err(e) => {
-                self.req_error_count += 1;
-                self.req_errors.insert(format!("{e}"));
-            }
-        }
+        self.row_count += row_count;
     }
 
     pub fn store_retry_error(&mut self, error_str: String) {


### PR DESCRIPTION
Add DynamoDB support with conditional compilation. Cassandra is the default and DynamoDB is activated through the `dynamodb` Cargo feature.

## Architecture Changes

- Moved Cassandra-specific code to `cassandra` subfolder in `scripting` module
- Created `dynamodb` subfolder for DynamoDB-specific code
- Extracted shared scripting functions and put them in `functions_common.rs`
- Created `common.rs` for shared database logic (`ClusterInfo`, `handle_retry_error`, `get_exponential_retry_interval`)
- Made `session.rs` database-agnostic

## Error Type Aliases

Both `dynamodb` and `cassandra` export their error types as `DbError` type aliases. Then mod.rs re-exports the appropriate module based on the active feature:

```rust
#[cfg(feature = "cassandra")]
pub use cassandra::cass_error as db_error;
#[cfg(feature = "dynamodb")]
pub use dynamodb::dynamodb_error as db_error;
```

This allows other latte code to always use `db_error::DbError` since both error types implement the same interface.

## Retry Logic

Moved `handle_retry_error` and `get_exponential_retry_interval` from `context.rs` to `common.rs` as they are the same for `dynamodb` and `cassandra`.

## Session Stats

Modified `session.rs` to be database-agnostic.

The error handling paths in `complete_request` and `complete_request_batch` were never actually used, the methods were only ever called on success.

## Code Removal

Removed `float_to_i8` as it was dead code.

## Building

```bash
# Cassandra
cargo build

# DynamoDB
cargo build --no-default-features --features dynamodb
```

## Drawbacks of this implementation
- Without a shared trait, care must be taken to keep the APIs of both `Context` types in sync manually.