### PR TITLE
Add commands for alternator to the Makefile and create latte-alternator binary target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,17 @@ authors = ["Piotr Kołaczkowski <pkolaczk@gmail.com>"]
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
+default-run = "latte"
 
 [[bin]]
 name = "latte"
 path = "src/main.rs"
+required-features = ["cql"]
+
+[[bin]]
+name = "latte-alternator"
+path = "src/main.rs"
+required-features = ["alternator"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,19 @@ clean:
 .PHONY: docker-build
 docker-build:
 	docker build --target production -t scylladb/latte:latest --compress .
+
+.PHONY: check-alternator
+check-alternator:
+	cargo check --all-targets --no-default-features --features alternator
+
+.PHONY: clippy-alternator
+clippy-alternator:
+	RUSTFLAGS=-Dwarnings cargo clippy --all-targets --no-default-features --features alternator
+
+.PHONY: test-alternator
+test-alternator:
+	cargo test --no-default-features --features alternator
+
+.PHONY: build-alternator
+build-alternator:
+	cargo build --examples --benches --no-default-features --features alternator


### PR DESCRIPTION
Added alternator commands to the `Makefile`. Created binary target for alternator so both latte versions can be installed at the same time. To install latte-alternator use:
```
cargo install --no-default-features --features alternator --path . --locked --bin latte-alternator
```
closes #18 