### PR TITLE
Implement batch_get_item and batch_write_item.

### DIFF
--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -7,7 +7,7 @@ use crate::scripting::retry_error::handle_retry_error;
 
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
-use super::types::rune_object_to_alternator_map;
+use super::types::{alternator_map_to_rune_object, rune_object_to_alternator_map};
 use super::types::{BSET_KEY, NSET_KEY, SSET_KEY};
 use aws_sdk_dynamodb::client::Waiters;
 use aws_sdk_dynamodb::types::{
@@ -75,10 +75,11 @@ fn extract_attribute_names(
         .collect::<Result<_, _>>()
 }
 
-async fn handle_request(
+async fn handle_request_with_pagination(
     ctx: &Context,
     builder: impl AlternatorRequest,
-) -> Result<Vec<Value>, AlternatorError> {
+    auto_paginate: bool,
+) -> Result<(Vec<Value>, Option<PaginationToken>), AlternatorError> {
     let mut token: Option<PaginationToken> = None;
     let mut current_attempt_num = 0;
     let mut all_pages_duration = Duration::ZERO;
@@ -113,20 +114,28 @@ async fn handle_request(
                             .try_lock()
                             .unwrap()
                             .complete_request(all_pages_duration, total_item_count);
-                        return Ok(all_items);
+                        return Ok((all_items, token));
                     }
                 }
 
                 if token.is_some() && builder.has_pagination() {
-                    current_attempt_num = 0; // reset retries for next page
-                    continue;
+                    if auto_paginate {
+                        current_attempt_num = 0; // reset retries for next page
+                        continue;
+                    } else {
+                        ctx.stats
+                            .try_lock()
+                            .unwrap()
+                            .complete_request(all_pages_duration, total_item_count);
+                        return Ok((all_items, token));
+                    }
                 }
 
                 ctx.stats
                     .try_lock()
                     .unwrap()
                     .complete_request(all_pages_duration, total_item_count);
-                return Ok(all_items);
+                return Ok((all_items, token));
             }
             Err(e) => {
                 let current_error = e;
@@ -139,6 +148,13 @@ async fn handle_request(
     Err(AlternatorError::query_retries_exceeded(ctx.retry_number))
 }
 
+async fn handle_request(
+    ctx: &Context,
+    builder: impl AlternatorRequest,
+) -> Result<Vec<Value>, AlternatorError> {
+    Ok(handle_request_with_pagination(ctx, builder, true).await?.0)
+}
+
 async fn handle_request_with_validation(
     ctx: &Context,
     builder: impl AlternatorRequest,
@@ -147,7 +163,7 @@ async fn handle_request_with_validation(
 ) -> Result<Vec<Value>, AlternatorError> {
     let mut current_attempt_num: u64 = 0;
     loop {
-        let result = handle_request(ctx, builder.clone()).await?;
+        let (result, _) = handle_request_with_pagination(ctx, builder.clone(), true).await?;
 
         let validation = match validation {
             None => return Ok(result),
@@ -181,6 +197,86 @@ async fn handle_request_with_validation(
             }
         }
     }
+}
+
+fn format_batch_result(
+    items: Vec<Value>,
+    token: Option<PaginationToken>,
+    auto_paginate: bool,
+    with_result: bool,
+    table_name: &str,
+) -> Result<Value, AlternatorError> {
+    if !with_result {
+        return Ok(Value::EmptyTuple);
+    }
+
+    if auto_paginate {
+        return Ok(items.to_value().into_result()?);
+    }
+
+    let mut res_obj = rune::runtime::Object::new();
+
+    res_obj.insert(
+        rune::alloc::String::try_from("items")?,
+        items.to_value().into_result()?,
+    )?;
+
+    match token {
+        Some(PaginationToken::UnprocessedKeys(mut u_keys)) => {
+            let keys: Vec<Value> = u_keys
+                .remove(table_name)
+                .map(|k| k.keys)
+                .unwrap_or_default()
+                .into_iter()
+                .map(alternator_map_to_rune_object)
+                .collect::<Result<_, _>>()?;
+
+            res_obj.insert(
+                rune::alloc::String::try_from("unprocessed_keys")?,
+                keys.to_value().into_result()?,
+            )?;
+        }
+        Some(PaginationToken::UnprocessedItems(mut u_items)) => {
+            let requests: Vec<Value> = u_items
+                .remove(table_name)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|req| {
+                    let mut o = rune::runtime::Object::new();
+
+                    if let Some(put) = req.put_request {
+                        o.insert(
+                            rune::alloc::String::try_from("type")?,
+                            "put".to_value().into_result()?,
+                        )?;
+                        o.insert(
+                            rune::alloc::String::try_from("item")?,
+                            alternator_map_to_rune_object(put.item)?,
+                        )?;
+                    } else if let Some(del) = req.delete_request {
+                        o.insert(
+                            rune::alloc::String::try_from("type")?,
+                            "delete".to_value().into_result()?,
+                        )?;
+                        o.insert(
+                            rune::alloc::String::try_from("key")?,
+                            alternator_map_to_rune_object(del.key)?,
+                        )?;
+                    }
+
+                    Ok(Value::Object(Shared::new(o)?))
+                })
+                .collect::<Result<_, AlternatorError>>()?;
+
+            res_obj.insert(
+                rune::alloc::String::try_from("unprocessed_items")?,
+                requests.to_value().into_result()?,
+            )?;
+        }
+        _ => {}
+    }
+
+    Ok(Value::Object(Shared::new(res_obj)?))
 }
 
 /// Creates a new table.
@@ -429,6 +525,7 @@ pub async fn update(
 /// * `options` - Optional parameters. An object containing:
 ///   - `consistent_read`: Boolean to enable consistent read for all keys (default: false).
 ///   - `with_result`: If true, the retrieved items are returned (default: false).
+///   - `get_unprocessed`: If true, disables auto-pagination. When `with_result: true` returns an object with `items` and `unprocessed_keys`.
 #[rune::function(instance)]
 pub async fn batch_get_item(
     ctx: Ref<Context>,
@@ -447,11 +544,21 @@ pub async fn batch_get_item(
         })
         .collect::<Result<_, _>>()?;
 
+    let mut with_result = false;
+    let mut get_unprocessed = false;
+
     // BatchGetItem requires the keys to be wrapped in a KeysAndAttributes struct
     let mut keys_request_builder = KeysAndAttributes::builder().set_keys(Some(keys_list));
     if let Value::Object(opts) = &options {
-        if let Some(Value::Bool(consistent_read)) = opts.borrow_ref()?.get("consistent_read") {
+        let opts_ref = opts.borrow_ref()?;
+        if let Some(Value::Bool(consistent_read)) = opts_ref.get("consistent_read") {
             keys_request_builder = keys_request_builder.consistent_read(*consistent_read);
+        }
+        if let Some(Value::Bool(w)) = opts_ref.get("with_result") {
+            with_result = *w;
+        }
+        if let Some(Value::Bool(u)) = opts_ref.get("get_unprocessed") {
+            get_unprocessed = *u;
         }
     }
 
@@ -459,17 +566,16 @@ pub async fn batch_get_item(
         .batch_get_item()
         .request_items(table_name.deref(), keys_request_builder.build()?);
 
-    let result = handle_request(&ctx, builder).await?;
+    let (result_items, token) =
+        handle_request_with_pagination(&ctx, builder, !get_unprocessed).await?;
 
-    if let Value::Object(opts) = &options {
-        if let Some(Value::Bool(with_result)) = opts.borrow_ref()?.get("with_result") {
-            if *with_result {
-                return Ok(result.to_value().into_result()?);
-            }
-        }
-    }
-
-    Ok(Value::EmptyTuple)
+    format_batch_result(
+        result_items,
+        token,
+        !get_unprocessed,
+        with_result,
+        table_name.deref(),
+    )
 }
 
 /// Batch writes items to the table.
@@ -480,12 +586,15 @@ pub async fn batch_get_item(
 ///   - `type`: Either "put" or "delete".
 ///   - `item`: For put requests, the item object to insert.
 ///   - `key`: For delete requests, the key object to delete.
+/// * `options` - Optional parameters. An object containing:
+///   - `get_unprocessed`: If true, disables auto-pagination. Returns an object with `unprocessed_items`.
 #[rune::function(instance)]
 pub async fn batch_write_item(
     ctx: Ref<Context>,
     table_name: Ref<str>,
     write_requests: Ref<rune::runtime::Vec>,
-) -> Result<(), AlternatorError> {
+    options: Value,
+) -> Result<Value, AlternatorError> {
     let client = ctx.get_client()?;
 
     let writes = write_requests
@@ -533,13 +642,29 @@ pub async fn batch_write_item(
         })
         .collect::<Result<_, _>>()?;
 
+    let mut get_unprocessed = false;
+
+    if let Value::Object(opts) = &options {
+        let opts_ref = opts.borrow_ref()?;
+        if let Some(Value::Bool(x)) = opts_ref.get("get_unprocessed") {
+            get_unprocessed = *x;
+        }
+    }
+
     let builder = client
         .batch_write_item()
         .request_items(table_name.deref(), writes);
 
-    handle_request(&ctx, builder).await?;
+    let (result_items, token) =
+        handle_request_with_pagination(&ctx, builder, !get_unprocessed).await?;
 
-    Ok(())
+    format_batch_result(
+        result_items,
+        token,
+        !get_unprocessed,
+        get_unprocessed,
+        table_name.deref(),
+    )
 }
 
 /// Queries items from the table.

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -11,7 +11,8 @@ use super::types::rune_object_to_alternator_map;
 use super::types::{BSET_KEY, NSET_KEY, SSET_KEY};
 use aws_sdk_dynamodb::client::Waiters;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+    AttributeDefinition, DeleteRequest, KeySchemaElement, KeyType, KeysAndAttributes, PutRequest,
+    ScalarAttributeType, WriteRequest,
 };
 use rune::runtime::{Object, Ref, Shared, VmResult};
 use rune::{ToValue, Value};
@@ -411,6 +412,130 @@ pub async fn update(
             attr_values.clone().into_ref()?,
         )?));
     }
+
+    handle_request(&ctx, builder).await?;
+
+    Ok(())
+}
+
+/// Batch retrieves items from the table.
+///
+/// If `with_result` is set to true, the retrieved items are returned as a `Vec<Object>`.
+/// Otherwise, the unit value is returned.
+///
+/// # Arguments
+/// * `table_name` - The name of the table.
+/// * `keys` - A list of items, where each item is an object representing a primary key.
+/// * `options` - Optional parameters. An object containing:
+///   - `consistent_read`: Boolean to enable consistent read for all keys (default: false).
+///   - `with_result`: If true, the retrieved items are returned (default: false).
+#[rune::function(instance)]
+pub async fn batch_get_item(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    keys: Ref<rune::runtime::Vec>,
+    options: Value,
+) -> Result<Value, AlternatorError> {
+    let client = ctx.get_client()?;
+
+    // Convert keys vector to DynamoDB keys
+    let keys_list = keys
+        .iter()
+        .map(|key_val| match key_val {
+            Value::Object(key_obj) => rune_object_to_alternator_map(key_obj.clone().into_ref()?),
+            _ => bad_input("Each key in the keys list must be an object"),
+        })
+        .collect::<Result<_, _>>()?;
+
+    // BatchGetItem requires the keys to be wrapped in a KeysAndAttributes struct
+    let mut keys_request_builder = KeysAndAttributes::builder().set_keys(Some(keys_list));
+    if let Value::Object(opts) = &options {
+        if let Some(Value::Bool(consistent_read)) = opts.borrow_ref()?.get("consistent_read") {
+            keys_request_builder = keys_request_builder.consistent_read(*consistent_read);
+        }
+    }
+
+    let builder = client
+        .batch_get_item()
+        .request_items(table_name.deref(), keys_request_builder.build()?);
+
+    let result = handle_request(&ctx, builder).await?;
+
+    if let Value::Object(opts) = &options {
+        if let Some(Value::Bool(with_result)) = opts.borrow_ref()?.get("with_result") {
+            if *with_result {
+                return Ok(result.to_value().into_result()?);
+            }
+        }
+    }
+
+    Ok(Value::EmptyTuple)
+}
+
+/// Batch writes items to the table.
+///
+/// # Arguments
+/// * `table_name` - The name of the table.
+/// * `write_requests` - A list of write requests. Each request is an object containing:
+///   - `type`: Either "put" or "delete".
+///   - `item`: For put requests, the item object to insert.
+///   - `key`: For delete requests, the key object to delete.
+#[rune::function(instance)]
+pub async fn batch_write_item(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    write_requests: Ref<rune::runtime::Vec>,
+) -> Result<(), AlternatorError> {
+    let client = ctx.get_client()?;
+
+    let writes = write_requests
+        .iter()
+        .map(|req_val| {
+            let Value::Object(req_obj) = req_val else {
+                return bad_input("Each write request must be an object");
+            };
+
+            let req_ref = req_obj.borrow_ref()?;
+
+            let req_type = match req_ref.get("type") {
+                Some(Value::String(t)) => t.borrow_ref()?.to_string(),
+                _ => return bad_input("Write request must have a 'type' field (put or delete)"),
+            };
+
+            match req_type.as_str() {
+                "put" => {
+                    let Some(Value::Object(item)) = req_ref.get("item") else {
+                        return bad_input("Put request must have an 'item' field");
+                    };
+
+                    let item_map = rune_object_to_alternator_map(item.clone().into_ref()?)?;
+
+                    Ok(WriteRequest::builder()
+                        .put_request(PutRequest::builder().set_item(Some(item_map)).build()?)
+                        .build())
+                }
+                "delete" => {
+                    let Some(Value::Object(key)) = req_ref.get("key") else {
+                        return bad_input("Delete request must have a 'key' field");
+                    };
+
+                    let key_map = rune_object_to_alternator_map(key.clone().into_ref()?)?;
+
+                    Ok(WriteRequest::builder()
+                        .delete_request(DeleteRequest::builder().set_key(Some(key_map)).build()?)
+                        .build())
+                }
+                _ => bad_input(format!(
+                    "Invalid request type: {}, must be 'put' or 'delete'",
+                    req_type
+                )),
+            }
+        })
+        .collect::<Result<_, _>>()?;
+
+    let builder = client
+        .batch_write_item()
+        .request_items(table_name.deref(), writes);
 
     handle_request(&ctx, builder).await?;
 

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -1,5 +1,7 @@
 use crate::config::ValidationStrategy;
-use crate::scripting::alternator::traits::{AlternatorRequest, IntoAlternatorOutput};
+use crate::scripting::alternator::traits::{
+    AlternatorRequest, IntoAlternatorOutput, PaginationToken,
+};
 use crate::scripting::functions_common::{extract_validation_args, ValidationArgs};
 use crate::scripting::retry_error::handle_retry_error;
 
@@ -76,7 +78,7 @@ async fn handle_request(
     ctx: &Context,
     builder: impl AlternatorRequest,
 ) -> Result<Vec<Value>, AlternatorError> {
-    let mut token: Option<HashMap<String, aws_sdk_dynamodb::types::AttributeValue>> = None;
+    let mut token: Option<PaginationToken> = None;
     let mut current_attempt_num = 0;
     let mut all_pages_duration = Duration::ZERO;
     let mut all_items = Vec::new();

--- a/src/scripting/alternator/traits.rs
+++ b/src/scripting/alternator/traits.rs
@@ -2,11 +2,12 @@ use super::alternator_error::AlternatorError;
 use super::types::alternator_map_to_rune_object;
 use aws_sdk_dynamodb::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_dynamodb::operation::{
+    batch_get_item::BatchGetItemOutput, batch_write_item::BatchWriteItemOutput,
     create_table::CreateTableOutput, delete_item::DeleteItemOutput,
     delete_table::DeleteTableOutput, get_item::GetItemOutput, put_item::PutItemOutput,
     query::QueryOutput, scan::ScanOutput, update_item::UpdateItemOutput,
 };
-use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::{AttributeValue, KeysAndAttributes, WriteRequest};
 use rune::Value;
 use std::collections::HashMap;
 use std::future::Future;
@@ -14,6 +15,8 @@ use std::future::Future;
 #[derive(Clone)]
 pub(super) enum PaginationToken {
     LastEvaluatedKey(HashMap<String, AttributeValue>),
+    UnprocessedKeys(HashMap<String, KeysAndAttributes>),
+    UnprocessedItems(HashMap<String, Vec<WriteRequest>>),
 }
 
 pub(super) type AlternatorOutputResult =
@@ -64,6 +67,38 @@ impl IntoAlternatorOutput for ScanOutput {
             self.last_evaluated_key
                 .map(PaginationToken::LastEvaluatedKey),
         ))
+    }
+}
+
+impl IntoAlternatorOutput for BatchGetItemOutput {
+    fn into_output(self) -> AlternatorOutputResult {
+        let responses = self.responses.unwrap_or_default();
+
+        let result = responses
+            .into_values()
+            .flatten()
+            .map(alternator_map_to_rune_object)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let len = result.len() as u64;
+
+        let token = self
+            .unprocessed_keys
+            .filter(|keys| !keys.is_empty())
+            .map(PaginationToken::UnprocessedKeys);
+
+        Ok((result, len, token))
+    }
+}
+
+impl IntoAlternatorOutput for BatchWriteItemOutput {
+    fn into_output(self) -> AlternatorOutputResult {
+        let token = self
+            .unprocessed_items
+            .filter(|keys| !keys.is_empty())
+            .map(PaginationToken::UnprocessedItems);
+
+        Ok((vec![], 0, token))
     }
 }
 
@@ -152,8 +187,12 @@ impl_alternator_request_no_pagination!(
     aws_sdk_dynamodb::operation::update_item::builders::UpdateItemFluentBuilder
 );
 
-impl_send_request!(aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder);
-impl_send_request!(aws_sdk_dynamodb::operation::scan::builders::ScanFluentBuilder);
+impl_send_request!(
+    aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder,
+    aws_sdk_dynamodb::operation::scan::builders::ScanFluentBuilder,
+    aws_sdk_dynamodb::operation::batch_get_item::builders::BatchGetItemFluentBuilder,
+    aws_sdk_dynamodb::operation::batch_write_item::builders::BatchWriteItemFluentBuilder
+);
 
 impl AlternatorRequest for aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder {
     fn set_pagination(self, token: Option<PaginationToken>, limit: Option<i32>) -> Self {
@@ -190,5 +229,41 @@ impl AlternatorRequest for aws_sdk_dynamodb::operation::scan::builders::ScanFlue
     }
     fn get_limit_val(&self) -> Option<i32> {
         *self.get_limit()
+    }
+}
+
+impl AlternatorRequest
+    for aws_sdk_dynamodb::operation::batch_get_item::builders::BatchGetItemFluentBuilder
+{
+    fn set_pagination(self, token: Option<PaginationToken>, _limit: Option<i32>) -> Self {
+        if let Some(PaginationToken::UnprocessedKeys(keys)) = token {
+            self.set_request_items(Some(keys))
+        } else {
+            self
+        }
+    }
+    fn has_pagination(&self) -> bool {
+        true
+    }
+    fn get_limit_val(&self) -> Option<i32> {
+        None
+    }
+}
+
+impl AlternatorRequest
+    for aws_sdk_dynamodb::operation::batch_write_item::builders::BatchWriteItemFluentBuilder
+{
+    fn set_pagination(self, token: Option<PaginationToken>, _limit: Option<i32>) -> Self {
+        if let Some(PaginationToken::UnprocessedItems(items)) = token {
+            self.set_request_items(Some(items))
+        } else {
+            self
+        }
+    }
+    fn has_pagination(&self) -> bool {
+        true
+    }
+    fn get_limit_val(&self) -> Option<i32> {
+        None
     }
 }

--- a/src/scripting/alternator/traits.rs
+++ b/src/scripting/alternator/traits.rs
@@ -11,8 +11,13 @@ use rune::Value;
 use std::collections::HashMap;
 use std::future::Future;
 
+#[derive(Clone)]
+pub(super) enum PaginationToken {
+    LastEvaluatedKey(HashMap<String, AttributeValue>),
+}
+
 pub(super) type AlternatorOutputResult =
-    Result<(Vec<Value>, u64, Option<HashMap<String, AttributeValue>>), AlternatorError>;
+    Result<(Vec<Value>, u64, Option<PaginationToken>), AlternatorError>;
 
 pub(super) trait IntoAlternatorOutput {
     fn into_output(self) -> AlternatorOutputResult;
@@ -36,7 +41,12 @@ impl IntoAlternatorOutput for QueryOutput {
             result.push(alternator_map_to_rune_object(item)?);
         }
         let len = result.len() as u64;
-        Ok((result, len, self.last_evaluated_key))
+        Ok((
+            result,
+            len,
+            self.last_evaluated_key
+                .map(PaginationToken::LastEvaluatedKey),
+        ))
     }
 }
 
@@ -48,7 +58,12 @@ impl IntoAlternatorOutput for ScanOutput {
             result.push(alternator_map_to_rune_object(item)?);
         }
         let len = result.len() as u64;
-        Ok((result, len, self.last_evaluated_key))
+        Ok((
+            result,
+            len,
+            self.last_evaluated_key
+                .map(PaginationToken::LastEvaluatedKey),
+        ))
     }
 }
 
@@ -94,11 +109,7 @@ pub(super) trait SendRequest {
 }
 
 pub(super) trait AlternatorRequest: SendRequest + Clone {
-    fn set_pagination(
-        self,
-        token: Option<HashMap<String, AttributeValue>>,
-        limit: Option<i32>,
-    ) -> Self;
+    fn set_pagination(self, token: Option<PaginationToken>, limit: Option<i32>) -> Self;
     fn has_pagination(&self) -> bool;
     fn get_limit_val(&self) -> Option<i32>;
 }
@@ -124,7 +135,7 @@ macro_rules! impl_alternator_request_no_pagination {
         $(
             impl_send_request!($t);
             impl AlternatorRequest for $t {
-                fn set_pagination(self, _: Option<HashMap<String, AttributeValue>>, _: Option<i32>) -> Self { self }
+                fn set_pagination(self, _: Option<PaginationToken>, _: Option<i32>) -> Self { self }
                 fn has_pagination(&self) -> bool { false }
                 fn get_limit_val(&self) -> Option<i32> { None }
             }
@@ -145,12 +156,11 @@ impl_send_request!(aws_sdk_dynamodb::operation::query::builders::QueryFluentBuil
 impl_send_request!(aws_sdk_dynamodb::operation::scan::builders::ScanFluentBuilder);
 
 impl AlternatorRequest for aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder {
-    fn set_pagination(
-        self,
-        token: Option<HashMap<String, AttributeValue>>,
-        limit: Option<i32>,
-    ) -> Self {
-        let mut b = self.set_exclusive_start_key(token);
+    fn set_pagination(self, token: Option<PaginationToken>, limit: Option<i32>) -> Self {
+        let mut b = self.set_exclusive_start_key(match token {
+            Some(PaginationToken::LastEvaluatedKey(key)) => Some(key),
+            _ => None,
+        });
         if let Some(limit) = limit {
             b = b.limit(limit);
         }
@@ -165,12 +175,11 @@ impl AlternatorRequest for aws_sdk_dynamodb::operation::query::builders::QueryFl
 }
 
 impl AlternatorRequest for aws_sdk_dynamodb::operation::scan::builders::ScanFluentBuilder {
-    fn set_pagination(
-        self,
-        token: Option<HashMap<String, AttributeValue>>,
-        limit: Option<i32>,
-    ) -> Self {
-        let mut b = self.set_exclusive_start_key(token);
+    fn set_pagination(self, token: Option<PaginationToken>, limit: Option<i32>) -> Self {
+        let mut b = self.set_exclusive_start_key(match token {
+            Some(PaginationToken::LastEvaluatedKey(key)) => Some(key),
+            _ => None,
+        });
         if let Some(limit) = limit {
             b = b.limit(limit);
         }

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -105,6 +105,8 @@ fn try_install(
     context_module.function_meta(functions::get)?;
     context_module.function_meta(functions::delete)?;
     context_module.function_meta(functions::update)?;
+    context_module.function_meta(functions::batch_get_item)?;
+    context_module.function_meta(functions::batch_write_item)?;
     context_module.function_meta(functions::query)?;
     context_module.function_meta(functions::scan)?;
 

--- a/workloads/alternator/batch_operations.rn
+++ b/workloads/alternator/batch_operations.rn
@@ -26,7 +26,7 @@ pub async fn run(db, i) {
         });
     }
     
-    db.batch_write_item(TABLE, write_requests).await?;
+    db.batch_write_item(TABLE, write_requests, ()).await?;
     
     let keys = [];
     for j in 0..batch_size {
@@ -56,7 +56,7 @@ pub async fn run(db, i) {
         });
     }
     
-    db.batch_write_item(TABLE, delete_requests).await?;
+    db.batch_write_item(TABLE, delete_requests, ()).await?;
 
     let result_after_delete = db.batch_get_item(TABLE, keys, #{
         consistent_read: true,

--- a/workloads/alternator/batch_operations.rn
+++ b/workloads/alternator/batch_operations.rn
@@ -1,0 +1,68 @@
+use latte::*;
+
+// Usage:
+// latte schema workloads/alternator/batch_operations.rn http://172.17.0.2:8000
+// latte run -d 1 workloads/alternator/batch_operations.rn http://172.17.0.2:8000
+
+const TABLE = "batch_ops_table";
+
+pub async fn schema(db) {
+    db.delete_table(TABLE).await;
+    db.create_table(TABLE, "pk").await?;
+}
+
+pub async fn run(db, i) {
+    let batch_size = 5;
+    let base_id = "user_" + i.to_string() + "_";
+    
+    let write_requests = [];
+    for j in 0..batch_size {
+        write_requests.push(#{
+            type: "put",
+            item: #{
+                pk: base_id + j.to_string(),
+                data: "batch_item_" + j.to_string()
+            }
+        });
+    }
+    
+    db.batch_write_item(TABLE, write_requests).await?;
+    
+    let keys = [];
+    for j in 0..batch_size {
+        keys.push(#{
+            pk: base_id + j.to_string(),
+        });
+    }
+    
+    db.batch_get_item(TABLE, keys, None).await?;
+    
+    // Batch get with result retrieval
+    let result = db.batch_get_item(TABLE, keys, #{
+        consistent_read: true,
+        with_result: true
+    }).await?;
+
+    // Check that we got the expected number of items back
+    assert!(result.len() == batch_size);
+    
+    let delete_requests = [];
+    for j in 0..batch_size {
+        delete_requests.push(#{
+            type: "delete",
+            key: #{
+                pk: base_id + j.to_string(),
+            }
+        });
+    }
+    
+    db.batch_write_item(TABLE, delete_requests).await?;
+
+    let result_after_delete = db.batch_get_item(TABLE, keys, #{
+        consistent_read: true,
+        with_result: true
+    }).await?;
+
+    // Make sure all items were deleted
+    assert!(result_after_delete.len() == 0);
+}

--- a/workloads/alternator/manual_batch_operations.rn
+++ b/workloads/alternator/manual_batch_operations.rn
@@ -1,0 +1,39 @@
+use latte::*;
+
+// Usage:
+// latte schema workloads/alternator/manual_batch_operations.rn http://172.17.0.2:8000
+// latte run -d 1 workloads/alternator/manual_batch_operations.rn http://172.17.0.2:8000
+
+const TABLE = "batch_ops_table";
+
+pub async fn schema(db) {
+    db.delete_table(TABLE).await;
+    db.create_table(TABLE, "pk").await?;
+}
+
+pub async fn run(db, i) {
+    let batch_size = 5;
+    let base_id = "user_" + i.to_string() + "_";
+    
+    let write_requests = [];
+    for j in 0..batch_size {
+        write_requests.push(#{
+            type: "put",
+            item: #{
+                pk: base_id + j.to_string(),
+                data: "batch_item_" + j.to_string()
+            }
+        });
+    }
+    
+    // Manual pagination loop for batch writes
+    let current_writes = write_requests;
+    while current_writes.len() > 0 {
+        let res = db.batch_write_item(TABLE, current_writes, #{ get_unprocessed: true }).await?;
+        if let Some(unprocessed) = res.get("unprocessed_items") {
+            current_writes = unprocessed;
+        } else {
+            current_writes = []; // All items processed
+        }
+    }
+}


### PR DESCRIPTION
Implemented the functions and added workflows that demonstrates the usage.

Batch operations support the `get_unprocessed` option that disables the auto pagination feature and allows the user to do it manually from rune.

Implementing the auto pagination feature required editing some existing traits.


Closes #22 