### PR TITLE
Introduce support for new alternator driver

### DIFF
--- a/ALTERNATOR.md
+++ b/ALTERNATOR.md
@@ -3,11 +3,10 @@
 **Benchmarks DynamoDB-compatible APIs (Amazon DynamoDB, ScyllaDB Alternator) using the same engine as CQL-based Latte**
 
 Latte ships a dedicated `latte-alternator` binary that speaks the DynamoDB protocol instead of CQL.
-It uses the AWS SDK for Rust under the hood and supports all the same execution features
-(async engine, rate/concurrency limiting, HDR histograms, reports, comparisons, etc.).
-
-> **Note:** The AWS SDK driver is planned to be replaced with the dedicated ScyllaDB Alternator driver,
-> which is currently under active development. The workload API will remain the same.
+It uses the dedicated ScyllaDB alternator-driver under the hood and supports all the same execution
+features (async engine, rate/concurrency limiting, HDR histograms, reports, comparisons, etc.), plus
+extra driver tuning options (datacenter/rack-aware routing, request compression, header optimization,
+node-refresh intervals and partition-key route affinity — see [Driver tuning](#driver-tuning)).
 
 ## Installation
 
@@ -54,6 +53,53 @@ where authentication is not required, you can set dummy credentials:
 export AWS_ACCESS_KEY_ID=dummy
 export AWS_SECRET_ACCESS_KEY=dummy
 export AWS_DEFAULT_REGION=us-east-1
+```
+
+### Driver tuning
+
+`latte-alternator` accepts a set of additional options that tune the underlying ScyllaDB
+alternator-driver. Unless noted otherwise, omitting an option leaves the driver default in place.
+
+#### Routing and load balancing
+
+`--datacenter` and `--rack` make the driver prefer nodes in the given datacenter and rack, narrowing
+the routing scope (rack → datacenter → whole cluster). `--routing-fallback` controls whether the
+driver falls back to a broader scope when the preferred one has no available nodes.
+
+| Option | Value | Default | Description |
+|--------|-------|---------|-------------|
+| `--datacenter` | `DC` | — | Datacenter to route requests to |
+| `--rack` | `RACK` | — | Rack to route requests to |
+| `--routing-fallback` | `BOOL` | driver default | Fall back to broader scopes (rack → dc → cluster) if the preferred scope has no nodes |
+| `--active-interval` | `MS` | driver default | Refresh interval for the known-nodes list while active |
+| `--idle-interval` | `MS` | driver default | Refresh interval for the known-nodes list while idle |
+| `--key-route-affinity` | `none` \| `rmw` \| `any-write` | `none` | Alternator write isolation mode for partition-key affinity routing |
+| `--key-route-affinity-table` | `TABLE=PK` | — | Pre-configured partition-key attribute name for a table (repeatable, e.g. `users=user_id`) |
+
+#### Request compression
+
+| Option | Value | Default | Description |
+|--------|-------|---------|-------------|
+| `--request-compression` | `driver-default` \| `off` \| `gzip` \| `zlib` | `driver-default` | How to compress request bodies before signing |
+| `--compression-threshold` | `BYTES` | `1024` | Minimum uncompressed body size before compression applies (`gzip` / `zlib` only) |
+| `--compression-level` | `1`–`9` | driver default | Deflate compression level (`gzip` / `zlib` only) |
+
+#### Headers
+
+| Option | Value | Default | Description |
+|--------|-------|---------|-------------|
+| `--optimize-headers` | `BOOL` | driver default (`true`) | Strip request headers not used by Alternator before transmit |
+
+Example invocations:
+
+```shell
+# Route to a specific datacenter and rack, with gzip request compression
+latte-alternator run workloads/alternator/api_demo.rn http://<host>:8000 \
+    --datacenter dc1 --rack rack1 --request-compression gzip --compression-level 6
+
+# Enable read-modify-write partition-key affinity for a table
+latte-alternator run workloads/alternator/api_demo.rn http://<host>:8000 \
+    --key-route-affinity rmw --key-route-affinity-table users=user_id
 ```
 
 ## Workloads

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alternator-driver"
+version = "0.1.0"
+source = "git+https://github.com/scylladb/alternator-client-rust?branch=master#87580bc41bb20869420505282c4f7718a83c4199"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "aws-runtime",
+ "aws-sdk-dynamodb",
+ "aws-smithy-async",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "dashmap",
+ "flate2",
+ "http-body-util",
+ "itertools",
+ "rand 0.10.1",
+ "reqwest 0.11.27",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,17 +482,23 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
  "http 1.4.0",
- "hyper",
- "hyper-rustls",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
+ "rustls 0.23.39",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tracing",
 ]
@@ -623,7 +653,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -642,7 +672,7 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -668,6 +698,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -713,7 +749,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.1",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -723,16 +759,16 @@ dependencies = [
  "home",
  "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-named-pipe",
- "hyper-rustls",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "hyperlocal",
  "log",
  "num",
  "pin-project-lite",
  "rand 0.9.4",
- "rustls",
+ "rustls 0.23.39",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -1607,6 +1643,25 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1790,6 +1845,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -1798,7 +1877,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1817,7 +1896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1827,17 +1906,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.39",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -1847,11 +1941,24 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1866,13 +1973,13 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1887,7 +1994,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2196,6 +2303,7 @@ dependencies = [
 name = "latte-cli"
 version = "0.49.0-scylladb"
 dependencies = [
+ "alternator-driver",
  "anyhow",
  "assert_approx_eq",
  "aws-config",
@@ -2224,7 +2332,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr",
  "regex",
- "reqwest",
+ "reqwest 0.13.2",
  "rmp",
  "rmp-serde",
  "rstest",
@@ -2246,6 +2354,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "try-lock",
+ "url",
  "uuid",
  "walkdir",
 ]
@@ -2280,7 +2389,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -2440,6 +2549,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,7 +2696,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2861,7 +2987,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.39",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -2882,7 +3008,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.39",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3053,7 +3179,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3062,7 +3188,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3137,6 +3263,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3147,12 +3313,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -3160,14 +3326,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.39",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -3434,11 +3600,23 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -3452,7 +3630,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3467,6 +3645,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -3490,10 +3677,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.39",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3505,6 +3692,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3583,6 +3780,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "scylla"
@@ -3677,7 +3884,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4021,6 +4228,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4047,13 +4260,34 @@ checksum = "00c99c9cda412afe293a6b962af651b4594161ba88c1affe7ef66459ea040a06"
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4071,6 +4305,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "termcolor"
@@ -4246,6 +4493,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-openssl"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,11 +4515,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.39",
  "tokio",
 ]
 
@@ -4360,17 +4627,17 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "socket2 0.6.3",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-stream",
  "tower",
@@ -4401,7 +4668,7 @@ dependencies = [
  "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -4415,7 +4682,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -4570,7 +4837,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.39",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
@@ -4787,7 +5054,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -4934,6 +5201,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4976,6 +5252,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -4998,6 +5289,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5010,6 +5307,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5019,6 +5322,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5040,6 +5349,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5049,6 +5364,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5064,6 +5385,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5073,6 +5400,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5093,6 +5426,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5159,7 +5502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,12 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 try-lock = "0.2.3"
+url = { version = "2.5", optional = true }
 uuid = { version = "1.1", features = ["v4"] }
 walkdir = "2"
 aws-sdk-dynamodb = { version = "1.111.0", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
 aws-config = { version = "1.8.16", optional = true }
+alternator-driver = { git = "https://github.com/scylladb/alternator-client-rust", branch = "master", optional = true }
 
 [build-dependencies]
 reqwest = { version = "0.13", features = ["json", "blocking"] }
@@ -86,7 +88,7 @@ testcontainers = "0.27"
 [features]
 default = ["cql"]
 cql = ["scylla"]
-alternator = ["aws-config", "aws-sdk-dynamodb"]
+alternator = ["alternator-driver", "aws-sdk-dynamodb", "aws-config", "url"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ To build the **alternator** (DynamoDB-compatible) binary instead:
 RUSTFLAGS="--cfg fetch_extended_version_info --cfg tokio_unstable" cargo install --path . --no-default-features --features alternator
 ```
 
+This produces the `latte-alternator` binary, which talks to ScyllaDB Alternator through the dedicated
+ScyllaDB alternator-driver. It exposes the same workload API as `latte` plus extra driver tuning
+options — see [ALTERNATOR.md](ALTERNATOR.md).
+
 ## From release binaries
 
 1. [Open Latte releases page on GitHub](https://github.com/scylladb/latte/releases)

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ const UNKNOWN: &str = "unknown";
 #[cfg(feature = "cql")]
 const DRIVER_PKG_NAME: &str = "scylla";
 #[cfg(feature = "alternator")]
-const DRIVER_PKG_NAME: &str = "aws-sdk-dynamodb";
+const DRIVER_PKG_NAME: &str = "alternator-driver";
 
 #[cfg(feature = "cql")]
 #[cfg(fetch_extended_version_info)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,6 +206,12 @@ pub struct ConnectionConf {
     #[clap(flatten)]
     #[serde(flatten)]
     pub db: db_config::DbConnectionConf,
+
+    /// Alternator-driver tuning (request compression and header handling).
+    #[cfg(feature = "alternator")]
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub alternator: db_config::AlternatorConnectionOpts,
 }
 
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
@@ -830,6 +836,71 @@ mod tests {
         #[test]
         fn empty_string_returns_none() {
             assert!(RetryInterval::new("").is_none());
+        }
+    }
+
+    #[cfg(feature = "alternator")]
+    mod alternator_connection_opts_tests {
+        use super::SchemaCommand;
+        use crate::scripting::db_config::AlternatorRequestCompressionMode;
+        use clap::Parser;
+
+        fn parse_schema(args: &[&str]) -> SchemaCommand {
+            SchemaCommand::try_parse_from(std::iter::once("latte").chain(args.iter().copied()))
+                .unwrap()
+        }
+
+        #[test]
+        fn default_options() {
+            let c = parse_schema(&["w.rn", "http://h:1"]);
+            assert_eq!(
+                c.connection.alternator.request_compression,
+                AlternatorRequestCompressionMode::DriverDefault
+            );
+            assert!(c.connection.alternator.optimize_headers.is_none());
+            assert_eq!(c.connection.alternator.compression_threshold, 1024);
+            assert!(c.connection.alternator.compression_level.is_none());
+        }
+
+        #[test]
+        fn parse_compression_flags() {
+            let c = parse_schema(&[
+                "w.rn",
+                "http://h:1",
+                "--request-compression",
+                "zlib",
+                "--optimize-headers",
+                "false",
+                "--compression-threshold",
+                "2048",
+                "--compression-level",
+                "7",
+            ]);
+            assert_eq!(
+                c.connection.alternator.request_compression,
+                AlternatorRequestCompressionMode::Zlib
+            );
+            assert_eq!(c.connection.alternator.optimize_headers, Some(false));
+            assert_eq!(c.connection.alternator.compression_threshold, 2048);
+            assert_eq!(c.connection.alternator.compression_level, Some(7));
+        }
+    }
+
+    #[cfg(feature = "alternator")]
+    mod parse_compression_level_tests {
+        use crate::scripting::db_config::parse_compression_level;
+
+        #[test]
+        fn accepts_levels_one_through_nine() {
+            for n in 1u8..=9u8 {
+                assert_eq!(parse_compression_level(&n.to_string()).unwrap(), n);
+            }
+        }
+
+        #[test]
+        fn rejects_out_of_range() {
+            assert!(parse_compression_level("0").is_err());
+            assert!(parse_compression_level("10").is_err());
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,7 @@ fn parse_f64(s: &str) -> Result<f64, String> {
 }
 
 /// Parse a single key-value pair
-fn parse_key_val<T, U>(s: &str) -> Result<(T, U), anyhow::Error>
+pub(crate) fn parse_key_val<T, U>(s: &str) -> Result<(T, U), anyhow::Error>
 where
     T: std::str::FromStr,
     T::Err: Error + Send + Sync + 'static,
@@ -855,7 +855,9 @@ mod tests {
     #[cfg(feature = "alternator")]
     mod alternator_connection_opts_tests {
         use super::SchemaCommand;
-        use crate::scripting::db_config::AlternatorRequestCompressionMode;
+        use crate::scripting::db_config::{
+            AlternatorKeyRouteAffinity, AlternatorRequestCompressionMode,
+        };
         use clap::Parser;
 
         fn parse_schema(args: &[&str]) -> SchemaCommand {
@@ -873,6 +875,13 @@ mod tests {
             assert!(c.connection.alternator.optimize_headers.is_none());
             assert_eq!(c.connection.alternator.compression_threshold, 1024);
             assert!(c.connection.alternator.compression_level.is_none());
+            assert!(c.connection.alternator.active_interval.is_none());
+            assert!(c.connection.alternator.idle_interval.is_none());
+            assert!(c.connection.datacenter.is_none());
+            assert!(c.connection.rack.is_none());
+            assert!(c.connection.alternator.routing_fallback.is_none());
+            assert!(c.connection.alternator.key_route_affinity.is_none());
+            assert!(c.connection.alternator.key_route_affinity_tables.is_empty());
         }
 
         #[test]
@@ -896,6 +905,46 @@ mod tests {
             assert_eq!(c.connection.alternator.optimize_headers, Some(false));
             assert_eq!(c.connection.alternator.compression_threshold, 2048);
             assert_eq!(c.connection.alternator.compression_level, Some(7));
+        }
+
+        #[test]
+        fn parse_optimization_flags() {
+            let c = parse_schema(&[
+                "w.rn",
+                "http://h:1",
+                "--active-interval",
+                "500",
+                "--idle-interval",
+                "30000",
+                "--datacenter",
+                "us-east-1",
+                "--rack",
+                "rack1a",
+                "--routing-fallback",
+                "false",
+                "--key-route-affinity",
+                "any-write",
+                "--key-route-affinity-table",
+                "users=user_id",
+                "--key-route-affinity-table",
+                "orders=order_id",
+            ]);
+            assert_eq!(c.connection.alternator.active_interval, Some(500));
+            assert_eq!(c.connection.alternator.idle_interval, Some(30000));
+            assert_eq!(c.connection.datacenter, Some("us-east-1".to_string()));
+            assert_eq!(c.connection.rack, Some("rack1a".to_string()));
+            assert_eq!(c.connection.alternator.routing_fallback, Some(false));
+            assert_eq!(
+                c.connection.alternator.key_route_affinity,
+                Some(AlternatorKeyRouteAffinity::AnyWrite)
+            );
+            assert_eq!(
+                c.connection.alternator.key_route_affinity_tables,
+                vec![
+                    ("users".to_string(), "user_id".to_string()),
+                    ("orders".to_string(), "order_id".to_string())
+                ]
+            );
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,6 +203,19 @@ pub struct ConnectionConf {
     )]
     pub validation_strategy: ValidationStrategy,
 
+    /// Datacenter to route requests to.
+    #[clap(long("datacenter"), required = false, value_name = "DC")]
+    pub datacenter: Option<String>,
+
+    /// Rack to route requests to.
+    #[clap(
+        long("rack"),
+        required = false,
+        value_name = "RACK",
+        requires = "datacenter"
+    )]
+    pub rack: Option<String>,
+
     #[clap(flatten)]
     #[serde(flatten)]
     pub db: db_config::DbConnectionConf,

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -529,6 +529,56 @@ impl Display for RunConfigCmp<'_> {
                     .map(|b| b.to_string())
                     .unwrap_or_else(|| "default".to_string())
             }),
+            #[cfg(feature = "alternator")]
+            self.line("Active interval", "", |conf| {
+                conf.connection
+                    .alternator
+                    .active_interval
+                    .map(|ms| format!("{} ms", ms))
+                    .unwrap_or_else(|| "default".to_string())
+            }),
+            #[cfg(feature = "alternator")]
+            self.line("Idle interval", "", |conf| {
+                conf.connection
+                    .alternator
+                    .idle_interval
+                    .map(|ms| format!("{} ms", ms))
+                    .unwrap_or_else(|| "default".to_string())
+            }),
+            #[cfg(feature = "alternator")]
+            self.line("Routing fallback", "", |conf| {
+                conf.connection
+                    .alternator
+                    .routing_fallback
+                    .map(|b| b.to_string())
+                    .unwrap_or_else(|| "default".to_string())
+            }),
+            #[cfg(feature = "alternator")]
+            self.line("Key route affinity", "", |conf| {
+                conf.connection
+                    .alternator
+                    .key_route_affinity
+                    .map(|a| format!("{:?}", a))
+                    .unwrap_or_else(|| "default".to_string())
+            }),
+            #[cfg(feature = "alternator")]
+            self.line("Key route affinity tables", "", |conf| {
+                if conf
+                    .connection
+                    .alternator
+                    .key_route_affinity_tables
+                    .is_empty()
+                {
+                    "none".to_string()
+                } else {
+                    conf.connection
+                        .alternator
+                        .key_route_affinity_tables
+                        .iter()
+                        .map(|(t, pk)| format!("{}={}", t, pk))
+                        .join(", ")
+                }
+            }),
             self.line("Tags", "", |conf| conf.tags.iter().join(", ")),
         ];
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -484,13 +484,11 @@ impl Display for RunConfigCmp<'_> {
             self.line("Cluster", "", |conf| {
                 OptionDisplay(conf.cluster_name.clone())
             }),
-            #[cfg(feature = "cql")]
             self.line("Datacenter", "", |conf| {
-                conf.connection.db.datacenter.clone().unwrap_or_default()
+                OptionDisplay(conf.connection.datacenter.clone())
             }),
-            #[cfg(feature = "cql")]
             self.line("Rack", "", |conf| {
-                conf.connection.db.rack.clone().unwrap_or_default()
+                OptionDisplay(conf.connection.rack.clone())
             }),
             self.line("DB version", "", |conf| {
                 OptionDisplay(conf.db_version.clone())

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -519,6 +519,18 @@ impl Display for RunConfigCmp<'_> {
                     .serial_consistency()
                     .to_string()
             }),
+            #[cfg(feature = "alternator")]
+            self.line("Request compression", "", |conf| {
+                format!("{:?}", conf.connection.alternator.request_compression)
+            }),
+            #[cfg(feature = "alternator")]
+            self.line("Optimize headers", "", |conf| {
+                conf.connection
+                    .alternator
+                    .optimize_headers
+                    .map(|b| b.to_string())
+                    .unwrap_or_else(|| "default".to_string())
+            }),
             self.line("Tags", "", |conf| conf.tags.iter().join(", ")),
         ];
 

--- a/src/scripting/alternator/address.rs
+++ b/src/scripting/alternator/address.rs
@@ -1,0 +1,80 @@
+/// Default Alternator listen port (see ALTERNATOR.md).
+pub(crate) const DEFAULT_ALTERNATOR_PORT: u16 = 8000;
+
+/// Parse an Alternator address, applying `http://` when no scheme is present and
+/// [`DEFAULT_ALTERNATOR_PORT`] when no port is specified.
+pub(crate) fn normalize_address(addr: &str) -> Option<url::Url> {
+    if addr.is_empty() {
+        return None;
+    }
+
+    let url_str = if addr.contains("://") {
+        addr.to_string()
+    } else {
+        format!("http://{addr}")
+    };
+
+    let mut url = url::Url::parse(&url_str).ok()?;
+    url.host_str()?;
+    if url.port().is_none() {
+        url.set_port(Some(DEFAULT_ALTERNATOR_PORT)).ok()?;
+    }
+    Some(url)
+}
+
+pub(crate) fn normalize_addresses(addresses: &[String]) -> Vec<url::Url> {
+    addresses
+        .iter()
+        .filter_map(|addr| normalize_address(addr))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_empty_address() {
+        assert!(normalize_address("").is_none());
+    }
+
+    #[test]
+    fn applies_default_scheme_and_port() {
+        let url = normalize_address("localhost").unwrap();
+        assert_eq!(url.scheme(), "http");
+        assert_eq!(url.host_str(), Some("localhost"));
+        assert_eq!(url.port(), Some(DEFAULT_ALTERNATOR_PORT));
+    }
+
+    #[test]
+    fn preserves_explicit_port() {
+        let url = normalize_address("http://127.0.0.1:9000").unwrap();
+        assert_eq!(url.port(), Some(9000));
+    }
+
+    #[test]
+    fn applies_default_port_to_host_without_port() {
+        let url = normalize_address("http://example.com").unwrap();
+        assert_eq!(url.port(), Some(DEFAULT_ALTERNATOR_PORT));
+    }
+
+    #[test]
+    fn host_port_without_scheme() {
+        let url = normalize_address("127.0.0.1:8000").unwrap();
+        assert_eq!(url.scheme(), "http");
+        assert_eq!(url.host_str(), Some("127.0.0.1"));
+        assert_eq!(url.port(), Some(8000));
+    }
+
+    #[test]
+    fn normalize_addresses_filters_empty() {
+        let urls = normalize_addresses(&[
+            "".to_string(),
+            "localhost".to_string(),
+            "http://node2:8000".to_string(),
+        ]);
+        assert_eq!(urls.len(), 2);
+        assert_eq!(urls[0].host_str(), Some("localhost"));
+        assert_eq!(urls[1].host_str(), Some("node2"));
+    }
+}

--- a/src/scripting/alternator/config.rs
+++ b/src/scripting/alternator/config.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Debug, Default, Serialize, Deserialize)]
@@ -20,6 +21,84 @@ pub struct DbConnectionConf {
     /// Region.
     #[clap(long("region"), default_value = "us-east-1")]
     pub region: String,
+}
+
+pub fn parse_compression_level(s: &str) -> Result<u8, String> {
+    let n: u8 = s
+        .parse()
+        .map_err(|_| format!("Invalid compression level: {s} (expected integer 1-9)"))?;
+    if (1..=9).contains(&n) {
+        Ok(n)
+    } else {
+        Err("Compression level must be between 1 and 9".to_string())
+    }
+}
+
+/// HTTP request body compression mode for the alternator-driver client.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum AlternatorRequestCompressionMode {
+    /// Use alternator-driver defaults.
+    #[default]
+    DriverDefault,
+    Off,
+    Gzip,
+    Zlib,
+}
+
+const DEFAULT_COMPRESSION_THRESHOLD: usize = 1024;
+
+/// Alternator-driver connection options.
+#[derive(Parser, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AlternatorConnectionOpts {
+    /// How to compress Alternator request bodies before signing.
+    #[clap(
+        long("request-compression"),
+        required = false,
+        default_value = "driver-default",
+        value_name = "MODE",
+        value_enum
+    )]
+    pub request_compression: AlternatorRequestCompressionMode,
+
+    /// Minimum uncompressed body size in bytes before compression applies (`gzip` / `zlib` only).
+    #[clap(
+        long("compression-threshold"),
+        required = false,
+        default_value_t = DEFAULT_COMPRESSION_THRESHOLD,
+        value_name = "BYTES"
+    )]
+    pub compression_threshold: usize,
+
+    /// Deflate compression level 1–9 (`gzip` / `zlib` only). If omitted, the driver default level is used.
+    #[clap(
+        long("compression-level"),
+        required = false,
+        value_name = "1-9",
+        value_parser = parse_compression_level
+    )]
+    pub compression_level: Option<u8>,
+
+    /// Strip request headers not used by Alternator before transmit. If omitted, the driver default (true) applies.
+    #[clap(long("optimize-headers"), required = false, value_name = "BOOL")]
+    pub optimize_headers: Option<bool>,
+}
+
+/// Serde hook: missing `compression_threshold` in a report must not deserialize as `usize::default()` (0).
+fn default_compression_threshold() -> usize {
+    DEFAULT_COMPRESSION_THRESHOLD
+}
+
+impl Default for AlternatorConnectionOpts {
+    fn default() -> Self {
+        Self {
+            request_compression: AlternatorRequestCompressionMode::default(),
+            compression_threshold: default_compression_threshold(),
+            compression_level: None,
+            optimize_headers: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/scripting/alternator/config.rs
+++ b/src/scripting/alternator/config.rs
@@ -1,3 +1,4 @@
+use crate::config::parse_key_val;
 use clap::Parser;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
@@ -46,6 +47,16 @@ pub enum AlternatorRequestCompressionMode {
     Zlib,
 }
 
+/// Alternator write isolation mode for partition-key affinity routing for the alternator-driver client.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum AlternatorKeyRouteAffinity {
+    #[default]
+    None,
+    Rmw,
+    AnyWrite,
+}
+
 const DEFAULT_COMPRESSION_THRESHOLD: usize = 1024;
 
 /// Alternator-driver connection options.
@@ -83,6 +94,36 @@ pub struct AlternatorConnectionOpts {
     /// Strip request headers not used by Alternator before transmit. If omitted, the driver default (true) applies.
     #[clap(long("optimize-headers"), required = false, value_name = "BOOL")]
     pub optimize_headers: Option<bool>,
+
+    /// Refresh interval in milliseconds for known nodes when active. If omitted, the driver default applies.
+    #[clap(long("active-interval"), required = false, value_name = "MS")]
+    pub active_interval: Option<u64>,
+
+    /// Refresh interval in milliseconds for known nodes when idle. If omitted, the driver default applies.
+    #[clap(long("idle-interval"), required = false, value_name = "MS")]
+    pub idle_interval: Option<u64>,
+
+    /// Whether to fall back to broader routing scopes if the preferred scope has no available nodes (e.g. rack -> dc -> cluster).
+    #[clap(long("routing-fallback"), required = false, value_name = "BOOL")]
+    pub routing_fallback: Option<bool>,
+
+    /// Partition-key affinity routing mode.
+    #[clap(
+        long("key-route-affinity"),
+        required = false,
+        value_name = "MODE",
+        value_enum
+    )]
+    pub key_route_affinity: Option<AlternatorKeyRouteAffinity>,
+
+    /// Pre-configured partition key attribute names for tables (e.g. `users=user_id`).
+    #[clap(
+        long("key-route-affinity-table"),
+        required = false,
+        value_parser = parse_key_val::<String, String>,
+        number_of_values = 1
+    )]
+    pub key_route_affinity_tables: Vec<(String, String)>,
 }
 
 /// Serde hook: missing `compression_threshold` in a report must not deserialize as `usize::default()` (0).
@@ -97,6 +138,11 @@ impl Default for AlternatorConnectionOpts {
             compression_threshold: default_compression_threshold(),
             compression_level: None,
             optimize_headers: None,
+            active_interval: None,
+            idle_interval: None,
+            routing_fallback: None,
+            key_route_affinity: None,
+            key_route_affinity_tables: Vec::new(),
         }
     }
 }

--- a/src/scripting/alternator/connect.rs
+++ b/src/scripting/alternator/connect.rs
@@ -1,7 +1,7 @@
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
+use super::driver::create_client;
 use crate::config::ConnectionConf;
-use alternator_driver::AlternatorClient as Client;
 use aws_config::retry::RetryConfig;
 use aws_config::BehaviorVersion;
 use aws_sdk_dynamodb::config::{Credentials, Region};
@@ -37,7 +37,7 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, AlternatorError> 
 
     let config = config_loader.load().await;
 
-    let client = Client::new(&config);
+    let client = create_client(&config, conf);
 
     // Validate connection by making a test request
     client.list_tables().limit(1).send().await.map_err(|e| {

--- a/src/scripting/alternator/connect.rs
+++ b/src/scripting/alternator/connect.rs
@@ -1,11 +1,11 @@
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
 use crate::config::ConnectionConf;
+use alternator_driver::AlternatorClient as Client;
 use aws_config::retry::RetryConfig;
 use aws_config::BehaviorVersion;
 use aws_sdk_dynamodb::config::{Credentials, Region};
 use aws_sdk_dynamodb::error::DisplayErrorContext;
-use aws_sdk_dynamodb::Client;
 
 pub async fn connect(conf: &ConnectionConf) -> Result<Context, AlternatorError> {
     let address = conf.addresses.first().cloned().unwrap_or_default();

--- a/src/scripting/alternator/connect.rs
+++ b/src/scripting/alternator/connect.rs
@@ -1,3 +1,4 @@
+use super::address::normalize_address;
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
 use super::driver::create_client;
@@ -8,7 +9,17 @@ use aws_sdk_dynamodb::config::{Credentials, Region};
 use aws_sdk_dynamodb::error::DisplayErrorContext;
 
 pub async fn connect(conf: &ConnectionConf) -> Result<Context, AlternatorError> {
-    let address = conf.addresses.first().cloned().unwrap_or_default();
+    let address = conf
+        .addresses
+        .iter()
+        .find_map(|addr| normalize_address(addr))
+        .ok_or_else(|| {
+            AlternatorError(AlternatorErrorKind::FailedToConnect(
+                conf.addresses.join(", "),
+                "no valid address".to_string(),
+            ))
+        })?
+        .to_string();
 
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest())
         .endpoint_url(&address)

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -4,7 +4,7 @@ use crate::error::LatteError;
 use crate::scripting::cluster_info::ClusterInfo;
 use crate::scripting::row_distribution::RowDistributionPreset;
 use crate::stats::session::SessionStats;
-use aws_sdk_dynamodb::Client;
+use alternator_driver::AlternatorClient as Client;
 use rune::runtime::Object;
 use rune::{Any, Value};
 use std::collections::HashMap;

--- a/src/scripting/alternator/driver.rs
+++ b/src/scripting/alternator/driver.rs
@@ -1,6 +1,8 @@
-use super::config::AlternatorRequestCompressionMode;
+use super::address::normalize_addresses;
+use super::config::{AlternatorKeyRouteAffinity, AlternatorRequestCompressionMode};
 use alternator_driver::{
-    AlternatorClient, AlternatorConfig, CompressionAlgorithm, CompressionLevel, RequestCompression,
+    keyrouting, AlternatorClient, AlternatorConfig, CompressionAlgorithm, CompressionLevel,
+    RequestCompression, RoutingScope,
 };
 
 pub fn create_client(
@@ -10,6 +12,34 @@ pub fn create_client(
     let opts = &conf.alternator;
 
     let mut builder = AlternatorConfig::new(sdk_config).to_builder();
+
+    let normalized = normalize_addresses(&conf.addresses);
+    let mut seed_hosts = Vec::with_capacity(normalized.len());
+    let mut detected_scheme = None;
+    let mut detected_port = None;
+
+    for url in &normalized {
+        if let Some(host) = url.host_str() {
+            seed_hosts.push(host.to_string());
+        }
+        if detected_scheme.is_none() {
+            detected_scheme = Some(url.scheme().to_string());
+        }
+        if detected_port.is_none() {
+            detected_port = url.port();
+        }
+    }
+
+    if !seed_hosts.is_empty() {
+        builder = builder.seed_hosts(seed_hosts);
+    }
+    if let Some(scheme) = detected_scheme {
+        builder = builder.scheme(scheme);
+    }
+    if let Some(port) = detected_port {
+        builder = builder.port(port);
+    }
+
     if let Some(optimize) = opts.optimize_headers {
         builder = builder.optimize_headers(optimize);
     }
@@ -41,5 +71,66 @@ pub fn create_client(
             ));
         }
     }
+
+    if let Some(active) = opts.active_interval {
+        builder = builder.active_interval(tokio::time::Duration::from_millis(active));
+    }
+    if let Some(idle) = opts.idle_interval {
+        builder = builder.idle_interval(tokio::time::Duration::from_millis(idle));
+    }
+
+    let routing_scope = match (&conf.datacenter, &conf.rack) {
+        (Some(dc), Some(rack)) => {
+            if opts.routing_fallback.unwrap_or(true) {
+                RoutingScope::from_rack(dc.clone(), rack.clone())
+                    .with_fallback(RoutingScope::from_datacenter(dc.clone()))
+                    .with_fallback(RoutingScope::from_cluster())
+            } else {
+                RoutingScope::from_rack(dc.clone(), rack.clone())
+            }
+        }
+        (Some(dc), None) => {
+            if opts.routing_fallback.unwrap_or(true) {
+                RoutingScope::from_datacenter(dc.clone())
+                    .with_fallback(RoutingScope::from_cluster())
+            } else {
+                RoutingScope::from_datacenter(dc.clone())
+            }
+        }
+        (None, Some(_)) => {
+            panic!("Datacenter must also be defined when rack is defined");
+        }
+        _ => RoutingScope::from_cluster(),
+    };
+    builder = builder.routing_scope(routing_scope);
+
+    let affinity_mode =
+        opts.key_route_affinity
+            .unwrap_or(if !opts.key_route_affinity_tables.is_empty() {
+                AlternatorKeyRouteAffinity::Rmw
+            } else {
+                AlternatorKeyRouteAffinity::None
+            });
+
+    if affinity_mode != AlternatorKeyRouteAffinity::None {
+        let affinity_type = match affinity_mode {
+            AlternatorKeyRouteAffinity::None => {
+                keyrouting::affinity_config::KeyRouteAffinityType::None
+            }
+            AlternatorKeyRouteAffinity::Rmw => {
+                keyrouting::affinity_config::KeyRouteAffinityType::Rmw
+            }
+            AlternatorKeyRouteAffinity::AnyWrite => {
+                keyrouting::affinity_config::KeyRouteAffinityType::AnyWrite
+            }
+        };
+        let mut affinity_builder =
+            keyrouting::affinity_config::KeyRouteAffinityConfig::builder().with_type(affinity_type);
+        for (table, pk) in &opts.key_route_affinity_tables {
+            affinity_builder = affinity_builder.with_pk_info(table, pk);
+        }
+        builder = builder.key_route_affinity(affinity_builder.build());
+    }
+
     AlternatorClient::from_conf(builder.build())
 }

--- a/src/scripting/alternator/driver.rs
+++ b/src/scripting/alternator/driver.rs
@@ -1,0 +1,45 @@
+use super::config::AlternatorRequestCompressionMode;
+use alternator_driver::{
+    AlternatorClient, AlternatorConfig, CompressionAlgorithm, CompressionLevel, RequestCompression,
+};
+
+pub fn create_client(
+    sdk_config: &aws_config::SdkConfig,
+    conf: &crate::config::ConnectionConf,
+) -> AlternatorClient {
+    let opts = &conf.alternator;
+
+    let mut builder = AlternatorConfig::new(sdk_config).to_builder();
+    if let Some(optimize) = opts.optimize_headers {
+        builder = builder.optimize_headers(optimize);
+    }
+    match opts.request_compression {
+        AlternatorRequestCompressionMode::DriverDefault => {}
+        AlternatorRequestCompressionMode::Off => {
+            builder = builder.request_compression(RequestCompression::disabled());
+        }
+        AlternatorRequestCompressionMode::Gzip => {
+            let level = opts
+                .compression_level
+                .map(|n| CompressionLevel::new(n as u32))
+                .unwrap_or_default();
+            builder = builder.request_compression(RequestCompression::enabled(
+                CompressionAlgorithm::Gzip,
+                level,
+                opts.compression_threshold,
+            ));
+        }
+        AlternatorRequestCompressionMode::Zlib => {
+            let level = opts
+                .compression_level
+                .map(|n| CompressionLevel::new(n as u32))
+                .unwrap_or_default();
+            builder = builder.request_compression(RequestCompression::enabled(
+                CompressionAlgorithm::Zlib,
+                level,
+                opts.compression_threshold,
+            ));
+        }
+    }
+    AlternatorClient::from_conf(builder.build())
+}

--- a/src/scripting/alternator/mod.rs
+++ b/src/scripting/alternator/mod.rs
@@ -2,6 +2,7 @@ pub mod alternator_error;
 pub mod config;
 pub mod connect;
 pub mod context;
+mod driver;
 pub mod functions;
 mod traits;
 pub mod types;

--- a/src/scripting/alternator/mod.rs
+++ b/src/scripting/alternator/mod.rs
@@ -1,3 +1,4 @@
+mod address;
 pub mod alternator_error;
 pub mod config;
 pub mod connect;

--- a/src/scripting/cql/config.rs
+++ b/src/scripting/cql/config.rs
@@ -44,14 +44,6 @@ pub struct DbConnectionConf {
     #[clap(long("ssl-peer-verification"))]
     pub ssl_peer_verification: bool,
 
-    /// Datacenter name
-    #[clap(long("datacenter"), required = false)]
-    pub datacenter: Option<String>,
-
-    /// Rack name
-    #[clap(long("rack"), required = false)]
-    pub rack: Option<String>,
-
     /// CQL query consistency level.
     /// 'SERIAL' and 'LOCAL_SERIAL' values are compatible only with SELECT statements
     /// and make Scylla use Paxos consensus algorithm

--- a/src/scripting/cql/connect.rs
+++ b/src/scripting/cql/connect.rs
@@ -35,8 +35,8 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, CassError> {
     let mut policy_builder = DefaultPolicy::builder().token_aware(true);
     let mut datacenter: String = "".to_string();
     let mut rack: String = "".to_string();
-    if let Some(dc) = &conf.db.datacenter {
-        if let Some(current_rack) = &conf.db.rack {
+    if let Some(dc) = &conf.datacenter {
+        if let Some(current_rack) = &conf.rack {
             policy_builder = policy_builder
                 .prefer_datacenter_and_rack(dc.to_owned(), current_rack.to_owned())
                 .permit_dc_failover(true);
@@ -47,7 +47,7 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, CassError> {
                 .permit_dc_failover(true);
         }
         datacenter = dc.clone();
-    } else if let Some(_rack) = &conf.db.rack {
+    } else if let Some(_rack) = &conf.rack {
         panic!("Datacenter must also be defined when rack is defined");
     }
     let profile = ExecutionProfile::builder()

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "cql")]
 const DRIVER_PKG_NAME: &str = "scylla";
 #[cfg(feature = "alternator")]
-const DRIVER_PKG_NAME: &str = "aws-sdk-dynamodb";
+const DRIVER_PKG_NAME: &str = "alternator-driver";
 
 #[derive(Debug)]
 pub struct VersionInfo {


### PR DESCRIPTION
Replaces dynamoDB driver with new Alternator driver. Implements support for driver specific optimizations. Latte now automatically fetches the driver from https://github.com/scylladb/alternator-client-rust when building. Closes #37 