### PR TITLE
Add support for DynamoDB Sets to Alternator. 

### DIFF
--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -6,11 +6,12 @@ use crate::scripting::retry_error::handle_retry_error;
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
 use super::types::rune_object_to_alternator_map;
+use super::types::{BSET_KEY, NSET_KEY, SSET_KEY};
 use aws_sdk_dynamodb::client::Waiters;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
 };
-use rune::runtime::{Object, Ref, Shared};
+use rune::runtime::{Object, Ref, Shared, VmResult};
 use rune::{ToValue, Value};
 use std::cmp::min;
 use std::collections::HashMap;
@@ -567,4 +568,31 @@ pub async fn scan(
     }
 
     Ok(Value::EmptyTuple)
+}
+
+/// Marks a list of items as an Alternator string set.
+#[rune::function]
+pub fn sset(items: Vec<Value>) -> VmResult<Value> {
+    let mut map = HashMap::new();
+    let items_val = rune::vm_try!(items.to_value());
+    map.insert(SSET_KEY.to_string(), items_val);
+    map.to_value()
+}
+
+/// Marks a list of items as an Alternator number set.
+#[rune::function]
+pub fn nset(items: Vec<Value>) -> VmResult<Value> {
+    let mut map = HashMap::new();
+    let items_val = rune::vm_try!(items.to_value());
+    map.insert(NSET_KEY.to_string(), items_val);
+    map.to_value()
+}
+
+/// Marks a list of items as an Alternator binary set.
+#[rune::function]
+pub fn bset(items: Vec<Value>) -> VmResult<Value> {
+    let mut map = HashMap::new();
+    let items_val = rune::vm_try!(items.to_value());
+    map.insert(BSET_KEY.to_string(), items_val);
+    map.to_value()
 }

--- a/src/scripting/alternator/types.rs
+++ b/src/scripting/alternator/types.rs
@@ -4,6 +4,56 @@ use rune::runtime::{Bytes, Object, Ref};
 use rune::{ToValue, Value};
 use std::collections::HashMap;
 
+pub const SSET_KEY: &str = "__sset";
+pub const NSET_KEY: &str = "__nset";
+pub const BSET_KEY: &str = "__bset";
+
+fn alternator_set_to_rune<I, T, F>(key: &str, iter: I, wrapper: F) -> Result<Value, AlternatorError>
+where
+    I: IntoIterator<Item = T>,
+    F: Fn(T) -> AttributeValue,
+{
+    let items = iter
+        .into_iter()
+        .map(|item| alternator_attribute_to_rune_value(wrapper(item)))
+        .collect::<Result<Vec<Value>, AlternatorError>>()?;
+
+    let mut map = HashMap::new();
+    map.insert(key.to_string(), items.to_value().into_result()?);
+    Ok(map.to_value().into_result()?)
+}
+
+fn rune_set_to_alternator<T, W, U>(
+    v: Value,
+    key: &str,
+    attribute_constructor: W,
+    rune_unwrapper: U,
+) -> Result<AttributeValue, AlternatorError>
+where
+    W: Fn(Vec<T>) -> AttributeValue,
+    U: Fn(AttributeValue) -> Option<T>,
+{
+    if let Value::Vec(vec) = v {
+        let items = vec
+            .into_ref()?
+            .iter()
+            .map(|item| {
+                rune_unwrapper(rune_value_to_alternator_attribute(item.clone())?).ok_or_else(|| {
+                    AlternatorError::new(AlternatorErrorKind::ConversionError(format!(
+                        "Invalid element type found in set {}: {:?}",
+                        key, item
+                    )))
+                })
+            })
+            .collect::<Result<Vec<T>, _>>()?;
+        Ok(attribute_constructor(items))
+    } else {
+        Err(AlternatorError::new(AlternatorErrorKind::ConversionError(
+            format!("Expected a vector of elements for {}", key),
+        )))
+    }
+}
+
 pub fn rune_value_to_alternator_attribute(v: Value) -> Result<AttributeValue, AlternatorError> {
     match v {
         Value::Bool(b) => Ok(AttributeValue::Bool(b)),
@@ -24,9 +74,50 @@ pub fn rune_value_to_alternator_attribute(v: Value) -> Result<AttributeValue, Al
                 .collect::<Result<_, _>>()?,
         )),
 
-        Value::Object(o) => Ok(AttributeValue::M(rune_object_to_alternator_map(
-            o.into_ref()?,
-        )?)),
+        Value::Object(o) => {
+            let obj = o.into_ref()?;
+
+            // Check for special Set representations.
+            // They have to be objects with exactly one key with special name, and the value has to be a vector of appropriate types.
+            if obj.len() == 1 {
+                let mut iter = obj.iter();
+                let (k, val) = iter.next().unwrap();
+
+                match k.as_str() {
+                    SSET_KEY => {
+                        return rune_set_to_alternator(val.clone(), k, AttributeValue::Ss, |a| {
+                            if let AttributeValue::S(s) = a {
+                                Some(s)
+                            } else {
+                                None
+                            }
+                        });
+                    }
+                    NSET_KEY => {
+                        return rune_set_to_alternator(val.clone(), k, AttributeValue::Ns, |a| {
+                            if let AttributeValue::N(n) = a {
+                                Some(n)
+                            } else {
+                                None
+                            }
+                        });
+                    }
+                    BSET_KEY => {
+                        return rune_set_to_alternator(val.clone(), k, AttributeValue::Bs, |a| {
+                            if let AttributeValue::B(b) = a {
+                                Some(b)
+                            } else {
+                                None
+                            }
+                        });
+                    }
+                    // Does not match any of the special set keys, so we treat it as a regular object.
+                    _ => {}
+                }
+            }
+
+            Ok(AttributeValue::M(rune_object_to_alternator_map(obj)?))
+        }
 
         Value::Option(o) => match o.into_ref()?.as_ref() {
             Some(v) => rune_value_to_alternator_attribute(v.clone()),
@@ -83,6 +174,10 @@ pub fn alternator_attribute_to_rune_value(attr: AttributeValue) -> Result<Value,
         AttributeValue::M(map) => Ok(alternator_map_to_rune_object(map)?),
 
         AttributeValue::Null(_) => Ok(None::<bool>.to_value().into_result()?),
+
+        AttributeValue::Ss(ss) => alternator_set_to_rune(SSET_KEY, ss, AttributeValue::S),
+        AttributeValue::Ns(ns) => alternator_set_to_rune(NSET_KEY, ns, AttributeValue::N),
+        AttributeValue::Bs(bs) => alternator_set_to_rune(BSET_KEY, bs, AttributeValue::B),
 
         _ => Err(AlternatorError::new(AlternatorErrorKind::ConversionError(
             format!("Unsupported Alternator AttributeValue type: {:?}", attr),

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -110,9 +110,13 @@ fn try_install(
 
     let err_module = init_error_module()?;
     let uuid_module = init_uuid_module()?;
-    let latte_module = init_latte_module(params)?;
+    let mut latte_module = init_latte_module(params)?;
     let mut fs_module = init_fs_module()?;
     let iter_module = init_iter_module(&mut fs_module)?;
+
+    latte_module.function_meta(functions::sset)?;
+    latte_module.function_meta(functions::nset)?;
+    latte_module.function_meta(functions::bset)?;
 
     rune_ctx.install(&context_module)?;
     rune_ctx.install(&err_module)?;

--- a/workloads/alternator/type_validation.rn
+++ b/workloads/alternator/type_validation.rn
@@ -32,6 +32,14 @@ pub async fn run(db, i) {
         // Binary "AttributeValue::B"
         test_bytes: b"binary data",
         
+        // Sets (AttributeValue::Ss, AttributeValue::Ns, AttributeValue::Bs)
+        test_string_set: sset(["a", "b", "c"]),
+        test_number_set: nset([1, 2, 3]),
+        test_bytes_set: bset([b"bar", b"foo"]),
+        manual_string_set: #{
+            __sset: ["x", "y", "z"]
+        },
+        
         // List "AttributeValue::L"
         test_list: [
             1, 
@@ -82,6 +90,18 @@ pub async fn run(db, i) {
     assert!(result["test_string"] == "Hello, World!");
 
     assert!(result["test_bytes"] ==  b"binary data");
+
+    // Validate set contents ignoring order
+    result["test_string_set"]["__sset"].sort();
+    result["test_number_set"]["__nset"].sort();
+    result["test_bytes_set"]["__bset"].sort();
+    result["manual_string_set"]["__sset"].sort();
+    assert!(result["test_string_set"] == sset(["a", "b", "c"]));
+    assert!(result["test_number_set"] == nset([1, 2, 3]));
+    assert!(result["test_bytes_set"] == bset([b"bar", b"foo"]));
+    assert!(result["manual_string_set"] == #{
+        __sset: ["x", "y", "z"]
+    });
 
     assert!(result["test_list"] == [
         1, 


### PR DESCRIPTION
Implemented support for passing and receiving of DynamoDB Sets to Rune.

They are implemented as objects with exactly one key with a special name. The values are stored as a vector of appropriate types. Convenience functions used to create the sets are provided to Rune.

Closes #36