### PR TITLE
Improve Rune parameter handling for Alternator API

### DIFF
--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -28,6 +28,22 @@ fn bad_input<T>(msg: impl Into<String>) -> Result<T, AlternatorError> {
     )))
 }
 
+fn check_invalid_params(
+    params: &Object,
+    function_name: &str,
+    allowed_fields: &[&str],
+) -> Result<(), AlternatorError> {
+    for field in params.keys() {
+        if !allowed_fields.contains(&field.as_str()) {
+            return bad_input(format!(
+                "Invalid parameter for function {}: {}. Allowed parameters: {:?}",
+                function_name, field, allowed_fields
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Gets the name and type of a primary or sort key from a object.
 fn extract_key_definition(
     object: &Shared<Object>,
@@ -294,6 +310,14 @@ pub async fn create_table(
 ) -> Result<(), AlternatorError> {
     let client = ctx.get_client()?;
 
+    if let Value::Object(o) = &params {
+        check_invalid_params(
+            o.borrow_ref()?.deref(),
+            "create_table",
+            &["primary_key", "sort_key"],
+        )?;
+    }
+
     // Extract primary key definition
     let (pk_name, pk_type) = match &params {
         Value::String(s) => (s.borrow_ref()?.to_string(), ScalarAttributeType::S),
@@ -452,6 +476,11 @@ pub async fn get(
         .set_key(Some(rune_object_to_alternator_map(key)?));
 
     if let Value::Object(opts) = &options {
+        check_invalid_params(
+            opts.borrow_ref()?.deref(),
+            "get",
+            &["consistent_read", "with_result"],
+        )?;
         if let Some(Value::Bool(consistent_read)) = opts.borrow_ref()?.get("consistent_read") {
             builder = builder.consistent_read(*consistent_read);
         }
@@ -508,7 +537,11 @@ pub async fn update(
             attr_values.clone().into_ref()?,
         )?));
     }
-
+    check_invalid_params(
+        &params,
+        "update",
+        &["update", "attribute_names", "attribute_values"],
+    )?;
     handle_request(&ctx, builder).await?;
 
     Ok(())
@@ -580,7 +613,13 @@ pub async fn batch_get_item(
     let builder = client
         .batch_get_item()
         .set_request_items(Some(request_items));
-
+    if let Value::Object(opts) = &options {
+        check_invalid_params(
+            opts.borrow_ref()?.deref(),
+            "batch_get_item",
+            &["consistent_read", "with_result", "get_unprocessed"],
+        )?;
+    }
     let (result_items, token) =
         handle_request_with_pagination(&ctx, builder, !get_unprocessed).await?;
 
@@ -681,7 +720,13 @@ pub async fn batch_write_item(
     let builder = client
         .batch_write_item()
         .set_request_items(Some(request_items));
-
+    if let Value::Object(opts) = &options {
+        check_invalid_params(
+            opts.borrow_ref()?.deref(),
+            "batch_write_item",
+            &["get_unprocessed"],
+        )?;
+    }
     let (result_items, token) =
         handle_request_with_pagination(&ctx, builder, !get_unprocessed).await?;
 
@@ -760,7 +805,20 @@ pub async fn query(
     } else {
         None
     };
-
+    check_invalid_params(
+        &params,
+        "query",
+        &[
+            "query",
+            "filter",
+            "attribute_names",
+            "attribute_values",
+            "consistent_read",
+            "limit",
+            "validation",
+            "with_result",
+        ],
+    )?;
     let result = handle_request_with_validation(&ctx, builder, validation, "Query").await?;
 
     if let Some(Value::Bool(with_result)) = params.get("with_result") {
@@ -834,7 +892,19 @@ pub async fn scan(
     } else {
         None
     };
-
+    check_invalid_params(
+        &params,
+        "scan",
+        &[
+            "filter",
+            "attribute_names",
+            "attribute_values",
+            "consistent_read",
+            "limit",
+            "validation",
+            "with_result",
+        ],
+    )?;
     let result = handle_request_with_validation(&ctx, builder, validation, "Scan").await?;
 
     if let Some(Value::Bool(with_result)) = params.get("with_result") {

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -818,7 +818,10 @@ pub async fn scan(
 
     if let Some(limit_val) = params.get("limit") {
         builder = builder.limit(match limit_val {
-            Value::Integer(i) => *i as i32,
+            Value::Integer(i) => match i32::try_from(*i) {
+                Ok(val) => val,
+                Err(_) => return bad_input("limit is out of range"),
+            },
             _ => return bad_input("limit must be an integer"),
         });
     }

--- a/workloads/alternator/invalid_params.rn
+++ b/workloads/alternator/invalid_params.rn
@@ -1,0 +1,118 @@
+use latte::*;
+
+// Usage:
+// latte schema workloads/alternator/api_demo.rn http://172.17.0.2:8000
+// latte run -d 1 workloads/alternator/api_demo.rn http://172.17.0.2:8000
+
+const TABLE = "invalid_params";
+
+pub async fn schema(db) {
+    // Drop the table (ignoring errors if it doesn't exist) to ensure we always have the up-to-date schema.
+    db.delete_table(TABLE).await;
+    assert!(db.create_table(TABLE, #{
+        primry_key: "pk",
+        sort_ey: #{name: "sk", type: "N"}
+    }).await.is_err());
+}
+
+// Runs a sequence of operations to verify the API.
+pub async fn run(db, i) {
+    let user_id = "user_" + i.to_string();
+    let user_order = 1;
+
+    // GET
+    let key = #{
+        pk: user_id,
+        sk: user_order
+    };
+    assert!(db.get(TABLE, key, #{
+        consnt_read: true
+    }).await.is_err());
+
+    // UPDATE Item
+    assert!(db.update(TABLE, key, #{
+        upd: "SET #n = :new_name, age = :new_age",
+        "attrite_names": #{
+            "#n": "name"
+        },
+        "attribute_vals": #{
+            ":new_name": "Other name",
+            ":new_age": 21
+        }
+    }).await.is_err());
+
+    // QUERY
+    assert!(db.query(TABLE, #{
+        query: "pk = :pk",
+        "attribute_values": #{
+            ":pk": user_id
+        },
+        limit: 1,
+        consistent_read: true,
+        bad: 0,
+    }).await.is_err());
+
+    // QUERY with validation
+    assert!(db.query(TABLE, #{
+        query: "pk = :pk",
+        "attribute_values": #{
+            ":pk": user_id
+        },
+        val: [1]
+    }).await.is_err());
+
+    // SCAN
+    assert!(db.scan(TABLE, #{
+        filter: "age > :min_age",
+        "attribute_vals": #{
+            ":min_age": 18
+        }
+    }).await.is_err());
+
+    let batch_size = 5;
+    let base_id = `user_${i}_`;
+    
+    // Batch write item
+    let write_requests = #{};
+    write_requests[TABLE] = [];
+    for j in 0..batch_size {
+         write_requests[TABLE].push(#{
+            type: "put",
+            item: #{
+                pk: `${base_id}${j}`,
+                data: `batch_item_${j}`
+            }
+        });
+    }
+    
+    assert!(db.batch_write_item(write_requests, #{const_read: true}).await.is_err());
+
+    // Batch get item
+    let get_requests = #{};
+    get_requests[TABLE] = [];
+    for j in 0..batch_size {
+        get_requests[TABLE].push(#{
+            pk: `${base_id}${j}`,
+        });
+    }
+    
+    assert!(db.batch_get_item(get_requests,#{result: false}).await.is_err());
+
+    // Limit handling
+    assert!(db.query(TABLE, #{
+        query: "pk = :pk",
+        "attribute_values": #{
+            ":pk": user_id
+        },
+        limit: 1099511627776,
+        consistent_read: true
+    }).await.is_err());
+    
+    assert!(db.scan(TABLE, #{
+        filter: "age > :min_age",
+        "attribute_vals": #{
+            ":min_age": 18
+        },
+        limit: 1099511627776
+    }).await.is_err());
+}


### PR DESCRIPTION
Implemented a fix for invalid limit parameter parsing in scan operation #39. Now Alternator API notifies user about providing an invalid parameter. Implemented a workload testing the handling of invalid parameters. Closes #41 