### PR TITLE
Projection expression in Alternator API

### DIFF
--- a/ALTERNATOR.md
+++ b/ALTERNATOR.md
@@ -338,6 +338,56 @@ Use `--validation-strategy` to control behavior on failure:
 - `retry` — retry the read (useful for eventually-consistent scenarios)
 - `ignore` — count failures but continue the benchmark
 
+### Projection expressions
+
+To retrieve only a subset of attributes rather than the entire item, you can use projection expressions in `get`, `query`, and `scan` operations. For `batch_get_item`, you can specify projection expressions on a per-table basis using an extended configuration object.
+
+If the projected attributes contain DynamoDB reserved words (such as `name`, `status`, or `data`), you can use expression attribute names to define placeholders (starting with `#`) and map them to their actual names in the `attribute_names` parameter.
+
+#### In GET, QUERY, and SCAN operations
+
+```rust
+// GET with projection expression and attribute names
+db.get(TABLE, key, #{
+    projection_expression: "#n, age",
+    attribute_names: #{ "#n": "name" }
+}).await?;
+
+// QUERY with projection expression
+db.query(TABLE, #{
+    query: "pk = :pk",
+    projection_expression: "#n, age",
+    attribute_names: #{ "#n": "name" },
+    attribute_values: #{ ":pk": pk }
+}).await?;
+
+// SCAN with projection expression
+db.scan(TABLE, #{
+    projection_expression: "pk, #d",
+    attribute_names: #{ "#d": "data" }
+}).await?;
+```
+
+#### In BATCH GET operations
+
+For `batch_get_item`, instead of a list of keys, each table in the requests map can be configured with an object containing `keys`, and optionally `projection_expression` and `attribute_names`:
+
+```rust
+let requests = #{};
+requests[TABLE] = #{
+    keys: [
+        #{ pk: "user_0" },
+        #{ pk: "user_1" }
+    ],
+    projection_expression: "pk, #d",
+    attribute_names: #{ "#d": "data" }
+};
+
+let result = db.batch_get_item(requests, #{
+    with_result: true
+}).await?;
+```
+
 The alternator driver supports all DynamoDB attribute value types:
 
 | Rune type | DynamoDB type |

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -486,6 +486,8 @@ pub async fn delete(
 ///   (and sort key if the table has one).
 /// * `options` - Optional parameters object:
 ///   - `consistent_read`: Boolean to enable consistent read (default: false).
+///   - `projection_expression`: A string that identifies the attributes to retrieve (optional).
+///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names (optional).
 ///   - `with_result`: If true, the result item is returned (default: false).
 #[rune::function(instance)]
 pub async fn get(
@@ -502,9 +504,31 @@ pub async fn get(
         .set_key(Some(rune_object_to_alternator_map(&key)?));
 
     if let Ok(opts) = options.borrow_ref::<Object>() {
-        check_invalid_params(opts.deref(), "get", &["consistent_read", "with_result"])?;
+        check_invalid_params(
+            opts.deref(),
+            "get",
+            &[
+                "consistent_read",
+                "projection_expression",
+                "attribute_names",
+                "with_result",
+            ],
+        )?;
         if let Some(b) = opts.get("consistent_read").and_then(|v| v.as_bool().ok()) {
             builder = builder.consistent_read(b);
+        }
+        if let Some(proj) = opts
+            .get("projection_expression")
+            .and_then(|v| v.borrow_ref::<rune::alloc::String>().ok())
+        {
+            builder = builder.projection_expression(proj.as_str().to_string());
+        }
+        if let Some(attr_names) = opts
+            .get("attribute_names")
+            .and_then(|v| v.borrow_ref::<Object>().ok())
+        {
+            builder =
+                builder.set_expression_attribute_names(Some(extract_attribute_names(&attr_names)?));
         }
     }
 
@@ -577,7 +601,12 @@ pub async fn update(
 /// Otherwise, the unit value is returned.
 ///
 /// # Arguments
-/// * `requests` - An object mapping table names to a list of primary key objects.
+/// * `requests` - An object mapping table names to either:
+///   - A list of primary key objects (simple form), or
+///   - An object containing:
+///     - `keys`: A list of primary key objects (required).
+///     - `projection_expression`: A string that identifies the attributes to retrieve (optional).
+///     - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names (optional).
 /// * `options` - Optional parameters. An object containing:
 ///   - `consistent_read`: Boolean to enable consistent read for all tables (default: false).
 ///   - `with_result`: If true, the retrieved items are returned (default: false).
@@ -614,28 +643,88 @@ pub async fn batch_get_item(
 
     let request_items: HashMap<String, KeysAndAttributes> = requests
         .iter()
-        .map(|(table_name, keys_val)| {
-            let keys_vec = if let Ok(vec) = keys_val.borrow_ref::<rune::runtime::Vec>() {
-                vec
-            } else {
-                return bad_input("Each table's requests must be a list of keys");
-            };
+        .map(|(table_name, table_val)| {
+            // Each table entry can be either a plain list of keys or an object
+            // with keys, projection_expression, and attribute_names.
+            let (keys_list, projection, attr_names) =
+                if let Ok(keys_vec) = table_val.borrow_ref::<rune::runtime::Vec>() {
+                    let keys = keys_vec
+                        .iter()
+                        .map(|key_val| {
+                            if let Ok(key_obj) = key_val.borrow_ref::<Object>() {
+                                rune_object_to_alternator_map(&key_obj)
+                            } else {
+                                bad_input("Each key in the keys list must be an object")
+                            }
+                        })
+                        .collect::<Result<_, _>>()?;
+                    (keys, None, None)
+                } else if let Ok(obj_ref) = table_val.borrow_ref::<Object>() {
+                    check_invalid_params(
+                        &obj_ref,
+                        "batch_get_item request object",
+                        &["keys", "projection_expression", "attribute_names"],
+                    )?;
 
-            let keys_list = keys_vec
-                .iter()
-                .map(|key_val| {
-                    if let Ok(key_obj) = key_val.borrow_ref::<Object>() {
-                        rune_object_to_alternator_map(&key_obj)
+                    let keys = if let Some(v) = obj_ref.get("keys") {
+                        if let Ok(keys_vec) = v.borrow_ref::<rune::runtime::Vec>() {
+                            keys_vec
+                                .iter()
+                                .map(|key_val| {
+                                    if let Ok(key_obj) = key_val.borrow_ref::<Object>() {
+                                        rune_object_to_alternator_map(&key_obj)
+                                    } else {
+                                        bad_input("Each key in the keys list must be an object")
+                                    }
+                                })
+                                .collect::<Result<_, _>>()?
+                        } else {
+                            return bad_input("Table object must have a 'keys' list");
+                        }
                     } else {
-                        bad_input("Each key in the keys list must be an object")
-                    }
-                })
-                .collect::<Result<_, _>>()?;
+                        return bad_input("Table object must have a 'keys' list");
+                    };
 
-            let keys_and_attributes = KeysAndAttributes::builder()
+                    let projection = if let Some(v) = obj_ref.get("projection_expression") {
+                        if let Ok(s) = v.borrow_ref::<rune::alloc::String>() {
+                            Some(s.as_str().to_string())
+                        } else {
+                            return bad_input("projection_expression must be a string");
+                        }
+                    } else {
+                        None
+                    };
+
+                    let attr_names = if let Some(v) = obj_ref.get("attribute_names") {
+                        if let Ok(names) = v.borrow_ref::<Object>() {
+                            Some(extract_attribute_names(&names)?)
+                        } else {
+                            return bad_input("attribute_names must be an object");
+                        }
+                    } else {
+                        None
+                    };
+
+                    (keys, projection, attr_names)
+                } else {
+                    return bad_input(
+                        "Each table's requests must be a list of keys or an object with 'keys'",
+                    );
+                };
+
+            let mut builder = KeysAndAttributes::builder()
                 .set_keys(Some(keys_list))
-                .consistent_read(consistent_read)
-                .build()?;
+                .consistent_read(consistent_read);
+
+            if let Some(proj) = projection {
+                builder = builder.projection_expression(proj);
+            }
+
+            if let Some(names) = attr_names {
+                builder = builder.set_expression_attribute_names(Some(names));
+            }
+
+            let keys_and_attributes = builder.build()?;
 
             Ok((table_name.to_string(), keys_and_attributes))
         })
@@ -787,6 +876,7 @@ pub async fn batch_write_item(
 /// * `params` - Parameters for the query operation. An object containing:
 ///   - `query`: The key condition expression string (required).
 ///   - `filter`: The filter expression string (optional, applied after query).
+///   - `projection_expression`: A string that identifies the attributes to retrieve (optional).
 ///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names.
 ///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
 ///   - `consistent_read`: Boolean to enable consistent read (default: false).
@@ -812,6 +902,12 @@ pub async fn query(
     if let Some(v) = params.get("filter") {
         if let Ok(s) = v.borrow_ref::<rune::alloc::String>() {
             builder = builder.filter_expression(s.as_str().to_string());
+        }
+    }
+
+    if let Some(proj) = params.get("projection_expression") {
+        if let Ok(s) = proj.borrow_ref::<rune::alloc::String>() {
+            builder = builder.projection_expression(s.as_str().to_string());
         }
     }
 
@@ -861,6 +957,7 @@ pub async fn query(
         &[
             "query",
             "filter",
+            "projection_expression",
             "attribute_names",
             "attribute_values",
             "consistent_read",
@@ -887,6 +984,7 @@ pub async fn query(
 /// * `table_name` - The name of the table.
 /// * `params` - Parameters for the scan operation. An object containing:
 ///   - `filter`: The filter expression string (optional).
+///   - `projection_expression`: A string that identifies the attributes to retrieve (optional).
 ///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names.
 ///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
 ///   - `consistent_read`: Boolean to enable consistent read (default: false).
@@ -906,6 +1004,12 @@ pub async fn scan(
     if let Some(v) = params.get("filter") {
         if let Ok(s) = v.borrow_ref::<rune::alloc::String>() {
             builder = builder.filter_expression(s.as_str().to_string());
+        }
+    }
+
+    if let Some(proj) = params.get("projection_expression") {
+        if let Ok(s) = proj.borrow_ref::<rune::alloc::String>() {
+            builder = builder.projection_expression(s.as_str().to_string());
         }
     }
 
@@ -954,6 +1058,7 @@ pub async fn scan(
         "scan",
         &[
             "filter",
+            "projection_expression",
             "attribute_names",
             "attribute_values",
             "consistent_read",

--- a/workloads/alternator/api_demo.rn
+++ b/workloads/alternator/api_demo.rn
@@ -42,6 +42,14 @@ pub async fn run(db, i) {
         consistent_read: true
     }).await?;
 
+    // GET with projection expression - only retrieve specific attributes
+    db.get(TABLE, key, #{
+        projection_expression: "#n, age",
+        "attribute_names": #{
+            "#n": "name"
+        }
+    }).await?;
+
     // UPDATE Item
     db.update(TABLE, key, #{
         update: "SET #n = :new_name, age = :new_age",
@@ -64,6 +72,18 @@ pub async fn run(db, i) {
         consistent_read: true
     }).await?;
 
+    // QUERY with projection expression
+    db.query(TABLE, #{
+        query: "pk = :pk",
+        projection_expression: "#n, age",
+        "attribute_names": #{
+            "#n": "name"
+        },
+        "attribute_values": #{
+            ":pk": user_id
+        }
+    }).await?;
+
     // QUERY with validation
     db.query(TABLE, #{
         query: "pk = :pk",
@@ -78,6 +98,14 @@ pub async fn run(db, i) {
         filter: "age > :min_age",
         "attribute_values": #{
             ":min_age": 18
+        }
+    }).await?;
+
+    // SCAN with projection expression
+    db.scan(TABLE, #{
+        projection_expression: "pk, #n",
+        "attribute_names": #{
+            "#n": "name"
         }
     }).await?;
 

--- a/workloads/alternator/batch_operations.rn
+++ b/workloads/alternator/batch_operations.rn
@@ -47,6 +47,26 @@ pub async fn run(db, i) {
 
     // Check that we got the expected number of items back
     assert!(result.len() == batch_size);
+
+    // BATCH GET with projection expression (extended per-table object form).
+    // Each table maps to an object with `keys`, and optionally
+    // `projection_expression` / `attribute_names` for reserved-word aliasing.
+    let proj_requests = #{};
+    proj_requests[TABLE] = #{
+        keys: get_requests[TABLE],
+        projection_expression: "pk, #d",
+        "attribute_names": #{
+            "#d": "data"
+        }
+    };
+    let proj_result = db.batch_get_item(proj_requests, #{
+        with_result: true
+    }).await?;
+
+    assert!(proj_result.len() == batch_size);
+    // the returned items should have 'pk' and 'data' attributes since we projected them
+    assert!(proj_result[0].pk is String);
+    assert!(proj_result[0].data is String);
     
     let delete_requests = #{};
     delete_requests[TABLE] = [];


### PR DESCRIPTION
Implemented support for projection expressions for get_item, query, scan, batch_get_item (per-table) with expression_attribute_names support. Added example usage to `api_demo.rn` and `batch_operations.rn` workloads. This PR bases on #48. Closes #50 