### PR TITLE
Add support for condition expressions in Alternator write operations.

### DIFF
--- a/ALTERNATOR.md
+++ b/ALTERNATOR.md
@@ -91,7 +91,7 @@ pub async fn run(db, i) {
         name: "Random Name",
         age: 20,
         tags: ["a", "b", "c"]
-    }).await?;
+    }, ()).await?;
 
     // GET
     let key = #{ pk: pk, sk: sk };
@@ -121,7 +121,7 @@ pub async fn run(db, i) {
     }).await?;
 
     // DELETE
-    db.delete(TABLE, key).await?;
+    db.delete(TABLE, key, ()).await?;
 }
 ```
 
@@ -214,7 +214,7 @@ pub async fn insert(db, i) {
     db.put(TABLE, #{
         id: (i % ROW_COUNT).to_string(),
         data: latte::text(i, OBJECT_SIZE)
-    }).await?;
+    }, ()).await?;
 }
 
 pub async fn run(db, i) {
@@ -292,7 +292,7 @@ async fn generate_row(i) {
 
 pub async fn write(db, i) {
     let row = generate_row(i).await;
-    db.put(TABLE, row).await?;
+    db.put(TABLE, row, ()).await?;
 }
 
 pub async fn read(db, i) {
@@ -355,6 +355,56 @@ The alternator driver supports all DynamoDB attribute value types:
 | `Some(value)` | (inner value) |
 | `None` | NULL |
 
+### Conditional expressions
+
+DynamoDB operations `put`, `delete`, and `update` support writing, deleting, or updating items conditionally based on a `condition_expression`.
+When the condition is not met, the operation will fail with a `ConditionalCheckFailedException` (which is caught and handled by Latte's execution engine).
+
+#### Put and delete operations with conditions
+
+For `put` and `delete`, the condition expression and its expression parameter/value mappings are specified in the optional third argument `options` object:
+
+```rust
+// PUT only if the item does not already exist
+db.put(TABLE, #{
+    pk: pk,
+    sk: sk,
+    name: "New User",
+    age: 25
+}, #{
+    condition_expression: "attribute_not_exists(pk)"
+}).await?;
+
+// DELETE only if the user is older than 18
+db.delete(TABLE, #{ pk: pk, sk: sk }, #{
+    condition_expression: "age > :min_age",
+    attribute_values: #{ ":min_age": 18 }
+}).await?;
+```
+
+If no options are needed for `put` or `delete`, pass `()` (unit) as the third argument:
+```rust
+db.put(TABLE, item, ()).await?;
+db.delete(TABLE, key, ()).await?;
+```
+
+#### Update operations with conditions
+
+For `update`, the condition expression and its parameter/value mappings are included directly inside the `params` (third) argument alongside the `update` expression itself:
+
+```rust
+// UPDATE only if the current age matches the expected age
+db.update(TABLE, #{ pk: pk, sk: sk }, #{
+    update: "SET #n = :new_name",
+    condition_expression: "age = :expected_age",
+    attribute_names: #{ "#n": "name" },
+    attribute_values: #{
+        ":new_name": "Updated Name",
+        ":expected_age": 21
+    }
+}).await?;
+```
+
 ### Table creation options
 
 The `create_table` function supports two forms:
@@ -376,10 +426,10 @@ db.create_table("my_table", #{
 |--------|-------------|
 | `db.create_table(name, schema)` | Create a DynamoDB table |
 | `db.delete_table(name)` | Delete a table (ignores errors if not found) |
-| `db.put(table, item)` | PutItem |
+| `db.put(table, item, options)` | PutItem |
 | `db.get(table, key, options)` | GetItem |
 | `db.update(table, key, options)` | UpdateItem |
-| `db.delete(table, key)` | DeleteItem |
+| `db.delete(table, key, options)` | DeleteItem |
 | `db.query(table, options)` | Query |
 | `db.scan(table, options)` | Scan |
 | `db.batch_write_item(requests, options)` | BatchWriteItem |

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -431,18 +431,57 @@ pub async fn delete_table(ctx: Ref<Context>, table_name: Ref<str>) -> Result<(),
 /// # Arguments
 /// * `table_name` - The name of the table.
 /// * `item` - The item to insert. An object where keys are attribute names and values are attribute values.
+/// * `options` - Optional parameters object:
+///   - `condition_expression`: A condition that must be satisfied for the operation to succeed.
+///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names.
+///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
 #[rune::function(instance)]
 pub async fn put(
     ctx: Ref<Context>,
     table_name: Ref<str>,
     item: Ref<Object>,
+    options: Value,
 ) -> Result<(), AlternatorError> {
     let client = ctx.get_client()?;
 
-    let builder = client
+    let mut builder = client
         .put_item()
         .table_name(table_name.deref())
         .set_item(Some(rune_object_to_alternator_map(&item)?));
+
+    if let Ok(opts) = options.borrow_ref::<Object>() {
+        if let Some(condition_expression) = opts.get("condition_expression") {
+            if let Ok(ce_str) = condition_expression.borrow_ref::<rune::alloc::String>() {
+                builder = builder.condition_expression(ce_str.as_str().to_string());
+            }
+        }
+
+        if let Some(attr_names) = opts.get("attribute_names") {
+            if let Ok(attr_names_obj) = attr_names.borrow_ref::<Object>() {
+                builder = builder.set_expression_attribute_names(Some(extract_attribute_names(
+                    &attr_names_obj,
+                )?));
+            }
+        }
+
+        if let Some(attr_values) = opts.get("attribute_values") {
+            if let Ok(attr_values_obj) = attr_values.borrow_ref::<Object>() {
+                builder = builder.set_expression_attribute_values(Some(
+                    rune_object_to_alternator_map(&attr_values_obj)?,
+                ));
+            }
+        }
+
+        check_invalid_params(
+            opts.deref(),
+            "put",
+            &[
+                "condition_expression",
+                "attribute_names",
+                "attribute_values",
+            ],
+        )?;
+    }
 
     handle_request(&ctx, builder).await?;
 
@@ -455,18 +494,57 @@ pub async fn put(
 /// * `table_name` - The name of the table.
 /// * `key` - The primary key of the item to delete. An object containing the partition key
 ///   (and sort key if the table has one).
+/// * `options` - Optional parameters object:
+///   - `condition_expression`: A condition that must be satisfied for the operation to succeed.
+///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names.
+///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
 #[rune::function(instance)]
 pub async fn delete(
     ctx: Ref<Context>,
     table_name: Ref<str>,
     key: Ref<Object>,
+    options: Value,
 ) -> Result<(), AlternatorError> {
     let client = ctx.get_client()?;
 
-    let builder = client
+    let mut builder = client
         .delete_item()
         .table_name(table_name.deref())
         .set_key(Some(rune_object_to_alternator_map(&key)?));
+
+    if let Ok(opts) = options.borrow_ref::<Object>() {
+        if let Some(condition_expression) = opts.get("condition_expression") {
+            if let Ok(ce_str) = condition_expression.borrow_ref::<rune::alloc::String>() {
+                builder = builder.condition_expression(ce_str.as_str().to_string());
+            }
+        }
+
+        if let Some(attr_names) = opts.get("attribute_names") {
+            if let Ok(attr_names_obj) = attr_names.borrow_ref::<Object>() {
+                builder = builder.set_expression_attribute_names(Some(extract_attribute_names(
+                    &attr_names_obj,
+                )?));
+            }
+        }
+
+        if let Some(attr_values) = opts.get("attribute_values") {
+            if let Ok(attr_values_obj) = attr_values.borrow_ref::<Object>() {
+                builder = builder.set_expression_attribute_values(Some(
+                    rune_object_to_alternator_map(&attr_values_obj)?,
+                ));
+            }
+        }
+
+        check_invalid_params(
+            opts.deref(),
+            "delete",
+            &[
+                "condition_expression",
+                "attribute_names",
+                "attribute_values",
+            ],
+        )?;
+    }
 
     handle_request(&ctx, builder).await?;
 
@@ -527,6 +605,7 @@ pub async fn get(
 ///   (and sort key if the table has one).
 /// * `params` - Parameters for the update operation. An object containing:
 ///   - `update`: The update expression string.
+///   - `condition_expression`: A condition that must be satisfied for the operation to succeed.
 ///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names.
 ///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
 #[rune::function(instance)]
@@ -554,6 +633,11 @@ pub async fn update(
             builder = builder.set_expression_attribute_names(Some(extract_attribute_names(&obj)?));
         }
     }
+    if let Some(v) = params.get("condition_expression") {
+        if let Ok(s) = v.borrow_ref::<rune::alloc::String>() {
+            builder = builder.condition_expression(s.as_str().to_string());
+        }
+    }
 
     if let Some(v) = params.get("attribute_values") {
         if let Ok(obj) = v.borrow_ref::<Object>() {
@@ -564,7 +648,12 @@ pub async fn update(
     check_invalid_params(
         &params,
         "update",
-        &["update", "attribute_names", "attribute_values"],
+        &[
+            "update",
+            "condition_expression",
+            "attribute_names",
+            "attribute_values",
+        ],
     )?;
     handle_request(&ctx, builder).await?;
 

--- a/workloads/alternator/api_demo.rn
+++ b/workloads/alternator/api_demo.rn
@@ -54,6 +54,19 @@ pub async fn run(db, i) {
         }
     }).await?;
 
+    // UPDATE Item with condition
+    db.update(TABLE, key, #{
+        update: "SET #n = :cond_name",
+        condition_expression: "age = :expected_age",
+        "attribute_names": #{
+            "#n": "name"
+        },
+        "attribute_values": #{
+            ":cond_name": "Conditional Name",
+            ":expected_age": 21
+        }
+    }).await?;
+
     // QUERY
     db.query(TABLE, #{
         query: "pk = :pk",

--- a/workloads/alternator/api_demo.rn
+++ b/workloads/alternator/api_demo.rn
@@ -30,7 +30,7 @@ pub async fn run(db, i) {
             num: 1234567890,
             bool: true
         }
-    }).await?;
+    }, ()).await?;
 
     // GET
     let key = #{
@@ -82,5 +82,5 @@ pub async fn run(db, i) {
     }).await?;
 
     // DELETE Item
-    db.delete(TABLE, key).await?;
+    db.delete(TABLE, key, ()).await?;
 }

--- a/workloads/alternator/large_objects.rn
+++ b/workloads/alternator/large_objects.rn
@@ -26,7 +26,7 @@ pub async fn insert(db, i) {
     db.put(TABLE, #{
         id: id.to_string(),
         data: latte::text(i, OBJECT_SIZE)
-    }).await?;
+    }, ()).await?;
 }
 
 pub async fn run(db, i) {

--- a/workloads/alternator/performance.rn
+++ b/workloads/alternator/performance.rn
@@ -101,7 +101,7 @@ fn generate_item(pk_str, i) {
 
 pub async fn load(db, i) {
     let pk_str = get_key_name(i);
-    db.put(TABLE, generate_item(pk_str, i)).await?;
+    db.put(TABLE, generate_item(pk_str, i), ()).await?;
 }
 
 pub async fn get(db, i) {
@@ -130,5 +130,5 @@ pub async fn update(db, i) {
 pub async fn insert(db, i) {
     let key_num = ROW_COUNT + i;
     let pk_str = get_key_name(key_num);
-    db.put(TABLE, generate_item(pk_str, key_num)).await?;
+    db.put(TABLE, generate_item(pk_str, key_num), ()).await?;
 }

--- a/workloads/alternator/row_count_validation.rn
+++ b/workloads/alternator/row_count_validation.rn
@@ -30,7 +30,7 @@ pub async fn insert(db, i) {
     let pk = hash(partition.idx);
     let ck = hash(idx);
     
-    db.put(TABLE, #{pk: pk, ck: ck}).await?;
+    db.put(TABLE, #{pk: pk, ck: ck}, ()).await?;
 }
 
 pub async fn query(db, i) {

--- a/workloads/alternator/type_validation.rn
+++ b/workloads/alternator/type_validation.rn
@@ -65,7 +65,7 @@ pub async fn run(db, i) {
         test_option_none: None,
     };
 
-    db.put(TABLE, item).await?;
+    db.put(TABLE, item, ()).await?;
     
     // Retrieve the item and validate types
     let result_wrapped = db.get(TABLE, #{ pk: pk }, #{


### PR DESCRIPTION
Added support for condition expressions in Alternator write operations. This required introducing breaking changes into the interface for `put` and `delete` operations. Updated Alternator workloads for the interface changes. Added an example condition expression usage to `api_demo.rn`. This PR depends on #48. Closes #51 