### PR TITLE
Increase scylla memory for integration-test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -78,14 +78,14 @@ jobs:
             -p 9042:9042 \
             -p 8000:8000 \
             ${{ env.SCYLLADB_IMAGE_REGISTRY }}:${{ env.SCYLLADB_IMAGE_TAG }} \
-            --smp 1 --memory 512M --overprovisioned 1 --skip-wait-for-gossip-to-settle 0 \
+            --smp 1 --memory=1536M --overprovisioned 1 --skip-wait-for-gossip-to-settle 0 \
             --alternator-port 8000 --alternator-write-isolation always
           wait_for_cql scylladb-node1
           log_resources "after scylladb-node1"
 
           docker run -d --name scylladb-node2 \
             ${{ env.SCYLLADB_IMAGE_REGISTRY }}:${{ env.SCYLLADB_IMAGE_TAG }} \
-            --smp 1 --memory 512M --overprovisioned 1 --skip-wait-for-gossip-to-settle 0 \
+            --smp 1 --memory=1536M --overprovisioned 1 --skip-wait-for-gossip-to-settle 0 \
             --alternator-port 8000 --alternator-write-isolation always \
             --seeds="$(docker inspect --format='{{ .NetworkSettings.Networks.bridge.IPAddress }}' scylladb-node1)"
           wait_for_cql scylladb-node2
@@ -93,7 +93,7 @@ jobs:
 
           docker run -d --name scylladb-node3 \
             ${{ env.SCYLLADB_IMAGE_REGISTRY }}:${{ env.SCYLLADB_IMAGE_TAG }} \
-            --smp 1 --memory 512M --overprovisioned 1 --skip-wait-for-gossip-to-settle 0 \
+            --smp 1 --memory=1536M --overprovisioned 1 --skip-wait-for-gossip-to-settle 0 \
             --alternator-port 8000 --alternator-write-isolation always \
             --seeds="$(docker inspect --format='{{ .NetworkSettings.Networks.bridge.IPAddress }}' scylladb-node1)"
           wait_for_cql scylladb-node3


### PR DESCRIPTION
Increased scylla container memory from 512M to 1536M (1.5G) per container as it is the recommended minimum for running scylla in docker. https://docs.scylladb.com/manual/stable/operating-scylla/procedures/tips/best-practices-scylla-on-docker.html